### PR TITLE
Fix deserialization for MultiLineStrings and Polygons with holes

### DIFF
--- a/src/GeoJSON.Net.Tests/DeserializationTest.cs
+++ b/src/GeoJSON.Net.Tests/DeserializationTest.cs
@@ -118,5 +118,68 @@ namespace GeoJSON.Net.Tests
             Assert.IsTrue(coordinates.Latitude + 52.379790828551016 < 0.0001);
         }
 
+        [TestMethod]
+        public void MultiLineStringDeserialization()
+        {
+            #region geoJsonText
+            var geoJsonText = @"{
+        'type': 'MultiLineString',
+        'coordinates': [
+          [
+            [
+              5.3173828125,
+              52.379790828551016
+              
+            ],
+            [
+              5.456085205078125,
+              52.36721467920585
+            ],
+            [
+              5.386047363281249,
+              52.303440474272755,
+                4.23
+            ]
+          ],
+          [
+            [
+              5.3273828125,
+              52.379790828551016
+              
+            ],
+            [
+              5.486085205078125,
+              52.36721467920585
+            ],
+            [
+              5.426047363281249,
+              52.303440474272755,
+                4.23
+            ]
+          ]
+        ]
+      }";
+            #endregion
+            //geoJsonText = geoJsonText.Replace("\r\n", "");
+            var multiLineString = JsonConvert.DeserializeObject<MultiLineString>(geoJsonText, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+            Assert.IsNotNull(multiLineString);
+            Assert.IsNotNull(multiLineString.Coordinates);
+            Assert.AreEqual(2, multiLineString.Coordinates.Count);
+            Assert.AreEqual(3, multiLineString.Coordinates[0].Coordinates.Count);
+            Assert.AreEqual(3, multiLineString.Coordinates[1].Coordinates.Count);
+
+            var firstPoint = multiLineString.Coordinates[0].Coordinates[0] as GeographicPosition;
+            Assert.IsNotNull(firstPoint);
+            Assert.AreEqual(52.37979082, firstPoint.Latitude, 0.0001);
+            Assert.AreEqual(5.3173828125, firstPoint.Longitude, 0.0001);
+            Assert.IsTrue(!firstPoint.Altitude.HasValue);
+
+            var thirdPoint = multiLineString.Coordinates[0].Coordinates[2] as GeographicPosition;
+            Assert.IsNotNull(thirdPoint);
+            Assert.IsTrue(thirdPoint.Altitude.HasValue);
+            Assert.AreEqual(4.23, thirdPoint.Altitude.Value, 0.0001);
+
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/SerializationTest.cs
+++ b/src/GeoJSON.Net.Tests/SerializationTest.cs
@@ -76,6 +76,41 @@ namespace GeoJSON.Net.Tests
         }
 
         [TestMethod]
+        public void MultiLineStringSerialization()
+        {
+            var coordinates = new[]
+            {
+                new List<IPosition> 
+                { 
+                    new GeographicPosition(52.370725881211314, 4.889259338378906), 
+                    new GeographicPosition(52.3711451105601, 4.895267486572266), 
+                    new GeographicPosition(52.36931095278263, 4.892091751098633), 
+                    new GeographicPosition(52.370725881211314, 4.889259338378906) 
+                },
+                new List<IPosition> 
+                { 
+                    new GeographicPosition(52.370725881211314, 4.989259338378906), 
+                    new GeographicPosition(52.3711451105601, 4.995267486572266), 
+                    new GeographicPosition(52.36931095278263, 4.992091751098633), 
+                    new GeographicPosition(52.370725881211314, 4.989259338378906) 
+                },
+            };
+
+            var model = new MultiLineString(coordinates.Select(ca => new LineString(ca)).ToList());
+            var serializedData = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
+
+            var matches = Regex.Matches(serializedData, @"(?<coordinates>[0-9]+([.,][0-9]+))");
+
+            double lng;
+            double.TryParse(matches[0].Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out lng);
+
+            //Double precision can pose a problem 
+            Assert.IsTrue(Math.Abs(lng - 4.889259338378906) < 0.0000001);
+
+            Assert.IsTrue(!serializedData.Contains("latitude"));
+        }
+
+        [TestMethod]
         public void GeographicPositionSerialization()
         {
             var model = new GeoJSON.Net.Geometry.GeographicPosition(112.12, 10);

--- a/src/GeoJSON.Net/Geometry/MultiLineString.cs
+++ b/src/GeoJSON.Net/Geometry/MultiLineString.cs
@@ -7,6 +7,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using GeoJSON.Net.Converters;
+
 namespace GeoJSON.Net.Geometry
 {
     using System.Collections.Generic;
@@ -33,6 +35,7 @@ namespace GeoJSON.Net.Geometry
         /// </summary>
         /// <value>The Coordinates.</value>
         [JsonProperty(PropertyName = "coordinates", Required = Required.Always)]
+        [JsonConverter(typeof(PolygonConverter))]
         public List<LineString> Coordinates { get; private set; }
     }
 }


### PR DESCRIPTION
This makes deserialization and serialization for MultLineStrings work properly. As a side effect, it also fixes polygons with holes, since the deserialization for `coordinates` works the same for MultiLineString and Polygon. In this way, this PR fixes the same problem as #23.

Added tests to verify MultiLineString serialization and deserialization.
