### PR TITLE
Reimplement Equals and GetHashCode

### DIFF
--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
@@ -28,5 +28,30 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             Assert.IsInstanceOf<DefaultCRS>(point.CRS);
         }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var json = "{\"coordinates\":[90.65464646,53.2455662,200.4567],\"type\":\"Point\"}";
+
+            var point = JsonConvert.DeserializeObject<Point>(json);
+
+            var expected = DefaultCRS.Instance;
+            var actual = point.CRS;
+
+            Assert.AreEqual(expected, actual);
+
+            Assert.IsTrue(expected.Equals(actual));
+            Assert.IsTrue(actual.Equals(expected));
+
+            Assert.IsTrue(actual.Equals(actual));
+            Assert.IsTrue(expected.Equals(expected));
+
+            Assert.IsTrue(expected == actual);
+            Assert.IsTrue(actual == expected);
+
+            Assert.AreEqual(expected.GetHashCode(), actual.GetHashCode());
+
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
@@ -61,8 +61,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         [Test]
         public void Ctor_Throws_ArgumentExpection_When_Href_Is_Not_Dereferencable_Uri()
         {
+            System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en-US");
             var argumentExpection = Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS("http://not-a-valid-<>-url"); });
-
             Assert.AreEqual("must be a dereferenceable URI\r\nParameter name: href", argumentExpection.Message);
         }
 
@@ -76,6 +76,38 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Empty()
         {
             Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS(string.Empty); });
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var left = new LinkedCRS(Href);
+            var right = new LinkedCRS(Href);
+
+            Assert.AreEqual(left, right);
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(right.Equals(left));
+
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+
+            right = new LinkedCRS(Href + "?query=null");
+
+            Assert.AreNotEqual(left, right);
+
+            Assert.IsFalse(left == right);
+            Assert.IsFalse(right == left);
+
+            Assert.IsFalse(left.Equals(right));
+            Assert.IsFalse(right.Equals(left));
+
+            Assert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
@@ -48,5 +48,40 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         {
             Assert.Throws<ArgumentException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(string.Empty) }; });
         }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var name = "EPSG:31370";
+
+            var left = new NamedCRS(name);
+            var right = new NamedCRS(name);
+
+            Assert.AreEqual(left, right);
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(right.Equals(left));
+
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+
+            name = "EPSG:25832";
+            right = new NamedCRS(name);
+
+            Assert.AreNotEqual(left, right);
+
+            Assert.IsFalse(left == right);
+            Assert.IsFalse(right == left);
+
+            Assert.IsFalse(left.Equals(right));
+            Assert.IsFalse(right.Equals(left));
+
+            Assert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
@@ -34,5 +34,25 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             Assert.IsInstanceOf<UnspecifiedCRS>(featureCollection.CRS);
         }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var left = new UnspecifiedCRS();
+            var right = new UnspecifiedCRS();
+
+            Assert.AreEqual(left, right);
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(right.Equals(left));
+
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
@@ -152,6 +152,31 @@ namespace GeoJSON.Net.Tests.Geometry
             Assert.AreEqual(classWithGeometry, deserializedClassWithGeometry);
         }
 
+        [Test]
+        [TestCaseSource(typeof(GeometryTests), nameof(Geometries))]
+        public void Serialized_And_Deserialized_Equals_And_Share_HashCode(IGeometryObject geometry)
+        {
+            var classWithGeometry = new ClassWithGeometryProperty(geometry);
+
+            var json = JsonConvert.SerializeObject(classWithGeometry);
+
+            var deserializedClassWithGeometry = JsonConvert.DeserializeObject<ClassWithGeometryProperty>(json);
+
+            var actual = classWithGeometry;
+            var expected = deserializedClassWithGeometry;
+            
+            Assert.IsTrue(actual.Equals(expected));
+            Assert.IsTrue(actual.Equals(actual));
+
+            Assert.IsTrue(expected.Equals(actual));
+            Assert.IsTrue(expected.Equals(expected));
+
+            Assert.IsTrue(classWithGeometry == deserializedClassWithGeometry);
+            Assert.IsTrue(deserializedClassWithGeometry == classWithGeometry);
+
+            Assert.AreEqual(actual.GetHashCode(), expected.GetHashCode());
+        }
+
         private class ClassWithGeometryProperty
         {
             public ClassWithGeometryProperty(IGeometryObject geometry)

--- a/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
@@ -76,5 +76,46 @@ namespace GeoJSON.Net.Tests.Geometry
 
             Assert.AreEqual(expectedLineString, actualLineString);
         }
+
+        private LineString GetLineString(double offset = 0.0)
+        {
+            var coordinates = new List<GeographicPosition>
+            {
+                new GeographicPosition(52.370725881211314 + offset, 4.889259338378906 + offset),
+                new GeographicPosition(52.3711451105601 + offset, 4.895267486572266 + offset),
+                new GeographicPosition(52.36931095278263 + offset, 4.892091751098633 + offset),
+                new GeographicPosition(52.370725881211314 + offset, 4.889259338378906 + offset)
+            };
+            var lineString = new LineString(coordinates);
+            return lineString;
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var rnd = new System.Random();
+            var offset = rnd.NextDouble() * 60;
+            if (rnd.NextDouble() < 0.5)
+            {
+                offset *= -1;
+            }
+
+            var left = GetLineString(offset);
+            var right = GetLineString(offset);
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(right, left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.Inconclusive("GetHashCode test is inconclusive because the coordinates are not readonly");
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
@@ -59,5 +59,53 @@ namespace GeoJSON.Net.Tests.Geometry
 
             JsonAssert.AreEqual(expectedJson, actualJson);
         }
+
+        private LineString GetLineString(double offset = 0.0)
+        {
+            var coordinates = new List<IPosition>
+            {
+                new GeographicPosition(52.379790828551016 + offset, 5.3173828125 + offset),
+                new GeographicPosition(52.36721467920585 + offset, 5.456085205078125 + offset),
+                new GeographicPosition(52.303440474272755 + offset, 5.386047363281249 + offset, 4.23 + offset)
+            };
+            var lineString = new LineString(coordinates);
+            return lineString;
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var rnd = new System.Random();
+            var offset = rnd.NextDouble() * 60;
+            if (rnd.NextDouble() < 0.5)
+            {
+                offset *= -1;
+            }
+
+            var leftLine = new List<LineString>();
+            leftLine.Add(GetLineString(offset + 1));
+            leftLine.Add(GetLineString(offset + 2));
+
+            var left = new MultiLineString(leftLine);
+
+            var rightLine = new List<LineString>();
+            rightLine.Add(GetLineString(offset + 1));
+            rightLine.Add(GetLineString(offset + 2));
+
+            var right = new MultiLineString(rightLine);
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(right, left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
@@ -42,5 +42,44 @@ namespace GeoJSON.Net.Tests.Geometry
 
             Assert.AreEqual(expectedMultiPoint, actualMultiPoint);
         }
+
+        private List<Point> GetPoints(double offset)
+        {
+            var points = new List<Point>
+            {
+                new Point(new GeographicPosition(52.370725881211314 + offset, 4.889259338378906 + offset)),
+                new Point(new GeographicPosition(52.3711451105601 + offset, 4.895267486572266 + offset)),
+                new Point(new GeographicPosition(52.36931095278263 + offset, 4.892091751098633 + offset)),
+                new Point(new GeographicPosition(52.370725881211314 + offset, 4.889259338378906 + offset))
+            };
+            return points;
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var rnd = new System.Random();
+            var offset = rnd.NextDouble() * 60;
+            if (rnd.NextDouble() < 0.5)
+            {
+                offset *= -1;
+            }
+
+            var left = new MultiPoint(GetPoints(offset));
+            var right = new MultiPoint(GetPoints(offset));
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(right, left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
@@ -13,46 +13,52 @@ namespace GeoJSON.Net.Tests.Geometry
         {
             var json = GetExpectedJson();
 
-            var expectMultiPolygon = new MultiPolygon(new List<Polygon>
+            var expectMultiPolygon = GetMultiPolygon();
+
+            var actualMultiPolygon = JsonConvert.DeserializeObject<MultiPolygon>(json);
+
+            Assert.AreEqual(expectMultiPolygon, actualMultiPolygon);
+        }
+
+        private MultiPolygon GetMultiPolygon(double offset = 0.0)
+        {
+            var multiPolygon = new MultiPolygon(new List<Polygon>
             {
                 new Polygon(new List<LineString>
                 {
                     new LineString(new List<IPosition>
                     {
-                        new GeographicPosition(52.959676831105995, -2.6797102391514338), 
-                        new GeographicPosition(52.9608756693609, -2.6769029474483279), 
-                        new GeographicPosition(52.908449372833715, -2.6079763270327119), 
-                        new GeographicPosition(52.891287242948195, -2.5815104708998668), 
-                        new GeographicPosition(52.875476700983896, -2.5851645010668989), 
-                        new GeographicPosition(52.882954723868622, -2.6050779098387191), 
-                        new GeographicPosition(52.875255907042678, -2.6373482332006359), 
-                        new GeographicPosition(52.878791122091066, -2.6932445076063951), 
-                        new GeographicPosition(52.89564268523565, -2.6931334629377890), 
-                        new GeographicPosition(52.930592009390175, -2.6548779332193022), 
-                        new GeographicPosition(52.959676831105995, -2.6797102391514338)
+                        new GeographicPosition(52.959676831105995 + offset, -2.6797102391514338 + offset),
+                        new GeographicPosition(52.9608756693609 + offset, -2.6769029474483279 + offset),
+                        new GeographicPosition(52.908449372833715 + offset, -2.6079763270327119 + offset),
+                        new GeographicPosition(52.891287242948195 + offset, -2.5815104708998668 + offset),
+                        new GeographicPosition(52.875476700983896 + offset, -2.5851645010668989 + offset),
+                        new GeographicPosition(52.882954723868622 + offset, -2.6050779098387191 + offset),
+                        new GeographicPosition(52.875255907042678 + offset, -2.6373482332006359 + offset),
+                        new GeographicPosition(52.878791122091066 + offset, -2.6932445076063951 + offset),
+                        new GeographicPosition(52.89564268523565 + offset, -2.6931334629377890 + offset),
+                        new GeographicPosition(52.930592009390175 + offset, -2.6548779332193022 + offset),
+                        new GeographicPosition(52.959676831105995 + offset, -2.6797102391514338 + offset)
                     })
-                }), 
+                }),
                 new Polygon(new List<LineString>
                 {
                     new LineString(new List<IPosition>
                     {
-                        new GeographicPosition(52.89610842810761, -2.69628632041613), 
-                        new GeographicPosition(52.8894641454077, -2.75901233808515), 
-                        new GeographicPosition(52.89938894657412, -2.7663172788742449), 
-                        new GeographicPosition(52.90253773227807, -2.804554822840895), 
-                        new GeographicPosition(52.929801009654575, -2.83848602260174), 
-                        new GeographicPosition(52.94013913205788, -2.838979264607087), 
-                        new GeographicPosition(52.937353122653533, -2.7978187468478741), 
-                        new GeographicPosition(52.920394929466184, -2.772273870352612), 
-                        new GeographicPosition(52.926572918779222, -2.6996509024137052), 
-                        new GeographicPosition(52.89610842810761, -2.69628632041613)
+                        new GeographicPosition(52.89610842810761 + offset,-2.69628632041613 + offset),
+                        new GeographicPosition(52.8894641454077 + offset,-2.75901233808515 + offset),
+                        new GeographicPosition(52.89938894657412 + offset,-2.7663172788742449 + offset),
+                        new GeographicPosition(52.90253773227807 + offset,-2.804554822840895 + offset),
+                        new GeographicPosition(52.929801009654575 + offset,-2.83848602260174 + offset),
+                        new GeographicPosition(52.94013913205788 + offset,-2.838979264607087 + offset),
+                        new GeographicPosition(52.937353122653533 + offset,-2.7978187468478741 + offset),
+                        new GeographicPosition(52.920394929466184 + offset,-2.772273870352612 + offset),
+                        new GeographicPosition(52.926572918779222 + offset,-2.6996509024137052 + offset),
+                        new GeographicPosition(52.89610842810761 + offset, -2.69628632041613 + offset)
                     })
                 })
             });
-
-            var actualMultiPolygon = JsonConvert.DeserializeObject<MultiPolygon>(json);
-
-            Assert.AreEqual(expectMultiPolygon, actualMultiPolygon);
+            return multiPolygon;
         }
 
         [Test]
@@ -99,6 +105,33 @@ namespace GeoJSON.Net.Tests.Geometry
 
             // Assert
             JsonAssert.AreEqual(expectedJson, actualJson);
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var rnd = new System.Random();
+            var offset = rnd.NextDouble() * 60;
+            if (rnd.NextDouble() < 0.5)
+            {
+                offset *= -1;
+            }
+
+            var left = GetMultiPolygon(offset);
+            var right = GetMultiPolygon(offset);
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(right, left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
@@ -54,5 +54,23 @@ namespace GeoJSON.Net.Tests.Geometry
 
             Assert.AreEqual(expectedPoint, actualPoint);
         }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var json = "{\"coordinates\":[90.65464646,53.2455662],\"type\":\"Point\"}";
+
+            var expectedPoint = new Point(new GeographicPosition(53.2455662, 90.65464646));
+
+            var actualPoint = JsonConvert.DeserializeObject<Point>(json);
+
+            Assert.AreEqual(expectedPoint, actualPoint);
+            Assert.IsTrue(expectedPoint.Equals(actualPoint));
+            Assert.IsTrue(actualPoint.Equals(expectedPoint));
+
+            Assert.AreEqual(expectedPoint.GetHashCode(), actualPoint.GetHashCode());
+            Assert.Inconclusive("GetHashCode test is inconclusive because the coordinates are not readonly");
+        }
+
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
@@ -262,5 +262,49 @@ namespace GeoJSON.Net.Tests.Geometry
 
             Assert.AreEqual(expectedPolygon, actualPolygon);
         }
+
+        private Polygon GetPolygon(double offset = 0.0)
+        {
+            var polygon = new Polygon(new List<LineString>
+            {
+                new LineString(new List<GeographicPosition>
+                {
+                    new GeographicPosition(52.379790828551016 + offset, 5.3173828125 + offset),
+                    new GeographicPosition(52.36721467920585 + offset, 5.456085205078125 + offset),
+                    new GeographicPosition(52.303440474272755 + offset, 5.386047363281249 + offset, 4.23 + offset),
+                    new GeographicPosition(52.379790828551016 + offset, 5.3173828125 + offset),
+                })
+            });
+            return polygon;
+        }
+
+        [Test]
+        public void Equals_GetHashCode_Contract()
+        {
+            var rnd = new System.Random();
+            var offset = rnd.NextDouble() * 60;
+            if (rnd.NextDouble() < 0.5)
+            {
+                offset *= -1;
+            }
+
+            var left = GetPolygon(offset);
+            var right = GetPolygon(offset);
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(right, left);
+
+            Assert.IsTrue(left.Equals(right));
+            Assert.IsTrue(left.Equals(left));
+            Assert.IsTrue(right.Equals(left));
+            Assert.IsTrue(right.Equals(right));
+
+            Assert.IsTrue(left == right);
+            Assert.IsTrue(right == left);
+
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.Inconclusive("GetHashCode test is inconclusive because the coordinates are not readonly");
+        }
+
     }
 }

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/CRSBase.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/CRSBase.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using GeoJSON.Net.Converters;
+using System;
 
 namespace GeoJSON.Net.CoordinateReferenceSystem
 {
@@ -18,7 +19,7 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
     ///     Base class for all IGeometryObject implementing types
     /// </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    public abstract class CRSBase
+    public abstract class CRSBase : IEqualityComparer<CRSBase>, IEquatable<CRSBase>
     {
         /// <summary>
         ///     Gets the properties.
@@ -32,5 +33,125 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
         [JsonProperty(PropertyName = "type", Required = Required.Always)]
         [JsonConverter(typeof(StringEnumConverter))]
         public CRSType Type { get; internal set; }
+
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(this, obj as CRSBase);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(CRSBase other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(CRSBase left, CRSBase right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, right))
+            {
+                return false;
+            }
+
+            if (left.Type != right.Type)
+            {
+                return false;
+            }
+
+            var leftIsNull = ReferenceEquals(null, left.Properties);
+            var rightIsNull = ReferenceEquals(null, right.Properties);
+            var bothAreMissing = leftIsNull && rightIsNull;
+
+            if (bothAreMissing || leftIsNull != rightIsNull)
+            {
+                return bothAreMissing;
+            }
+
+            foreach (var item in left.Properties)
+            {
+                if (!right.Properties.ContainsKey(item.Key))
+                {
+                    return false;
+                }
+                if (!object.Equals(item.Value, right.Properties[item.Key]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(CRSBase left, CRSBase right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, right))
+            {
+                return false;
+            }
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
+        public static bool operator !=(CRSBase left, CRSBase right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
+        {
+            int hashCode = ((int)Type).GetHashCode();
+            if (Properties != null)
+            {
+                foreach (var item in Properties)
+                {
+                    string toString;
+                    if (item.Value == null)
+                    {
+                        toString = item.Key;
+                    }
+                    else
+                    {
+                        toString = $"{item.Key}:{item.Value.ToString()}";
+                    }
+                    hashCode = (hashCode * 397) ^ toString.GetHashCode();
+                }
+            }
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(CRSBase obj)
+        {
+            return obj.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/UnspecifiedCRS.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/UnspecifiedCRS.cs
@@ -16,5 +16,62 @@
                 return CRSType.Unspecified;
             }
         }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ICRSObject);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(ICRSObject obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return Type == obj.Type;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(UnspecifiedCRS left, UnspecifiedCRS right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, right))
+            {
+                return false;
+            }
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
+        public static bool operator !=(UnspecifiedCRS left, UnspecifiedCRS right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return Type.GetHashCode();
+        }
+
     }
 }

--- a/src/GeoJSON.Net/Geometry/GeographicPosition.cs
+++ b/src/GeoJSON.Net/Geometry/GeographicPosition.cs
@@ -8,6 +8,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -17,7 +18,7 @@ namespace GeoJSON.Net.Geometry
     ///     Defines the Geographic Position type a.k.a.
     ///     <see cref="http://geojson.org/geojson-spec.html#positions">Geographic Coordinate Reference System</see>.
     /// </summary>
-    public class GeographicPosition : Position
+    public class GeographicPosition : Position, IEqualityComparer<GeographicPosition>, IEquatable<GeographicPosition>
     {
         private static readonly NullableDoubleTenDecimalPlaceComparer DoubleComparer = new NullableDoubleTenDecimalPlaceComparer();
 
@@ -96,6 +97,7 @@ namespace GeoJSON.Net.Geometry
         ///     Prevents a default instance of the <see cref="GeographicPosition" /> class from being created.
         /// </summary>
         private GeographicPosition()
+            : base()
         {
             Coordinates = new double?[3];
         }
@@ -136,71 +138,7 @@ namespace GeoJSON.Net.Geometry
         ///     The coordinates.
         /// </value>
         private double?[] Coordinates { get; set; }
-
-        /// <summary>
-        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
-        /// </summary>
-        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
-
-            return Equals((GeographicPosition)obj);
-        }
-
-        /// <summary>
-        /// Returns a hash code for this instance.
-        /// </summary>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
-        /// </returns>
-        public override int GetHashCode()
-        {
-            return Coordinates != null ? Coordinates.GetHashCode() : 0;
-        }
-
-        /// <summary>
-        /// Implements the operator ==.
-        /// </summary>
-        /// <param name="left">The left.</param>
-        /// <param name="right">The right.</param>
-        /// <returns>
-        /// The result of the operator.
-        /// </returns>
-        public static bool operator ==(GeographicPosition left, GeographicPosition right)
-        {
-            return Equals(left, right);
-        }
-
-        /// <summary>
-        /// Implements the operator !=.
-        /// </summary>
-        /// <param name="left">The left.</param>
-        /// <param name="right">The right.</param>
-        /// <returns>
-        /// The result of the operator.
-        /// </returns>
-        public static bool operator !=(GeographicPosition left, GeographicPosition right)
-        {
-            return !Equals(left, right);
-        }
-
+        
         /// <summary>
         ///     Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
@@ -214,16 +152,78 @@ namespace GeoJSON.Net.Geometry
                 : string.Format(CultureInfo.InvariantCulture, "Latitude: {0}, Longitude: {1}, Altitude: {2}", Latitude, Longitude, Altitude);
         }
 
+        #region IEqualityComparer, IEquatable
+
         /// <summary>
-        /// Determines whether the specified <see cref="GeographicPosition" />, is equal to this instance.
+        /// Determines whether the specified object is equal to the current object
         /// </summary>
-        /// <param name="other">The <see cref="GeographicPosition" /> to compare with this instance.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified <see cref="GeographicPosition" /> is equal to this instance; otherwise, <c>false</c>.
-        /// </returns>
-        protected bool Equals(GeographicPosition other)
+        public override bool Equals(object obj)
         {
-            return Coordinates.SequenceEqual(other.Coordinates, DoubleComparer);
+            return (this == (obj as GeographicPosition));
         }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(GeographicPosition other)
+        {
+            return (this == other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(GeographicPosition left, GeographicPosition right)
+        {
+            return (left == right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(GeographicPosition left, GeographicPosition right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, right))
+            {
+                return false;
+            }
+            return left.Coordinates.SequenceEqual(right.Coordinates, DoubleComparer);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator !=(GeographicPosition left, GeographicPosition right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
+        {
+            int hash = 1;
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(GeographicPosition other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
+
     }
 }

--- a/src/GeoJSON.Net/Geometry/GeometryCollection.cs
+++ b/src/GeoJSON.Net/Geometry/GeometryCollection.cs
@@ -18,7 +18,7 @@ namespace GeoJSON.Net.Geometry
     /// <summary>
     ///     Defines the <see cref="http://geojson.org/geojson-spec.html#geometry-collection">GeometryCollection</see> type.
     /// </summary>
-    public class GeometryCollection : GeoJSONObject, IGeometryObject
+    public class GeometryCollection : GeoJSONObject, IGeometryObject, IEqualityComparer<GeometryCollection>, IEquatable<GeometryCollection>
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="GeometryCollection" /> class.
@@ -32,6 +32,7 @@ namespace GeoJSON.Net.Geometry
         /// </summary>
         /// <param name="geometries">The geometries contained in this GeometryCollection.</param>
         public GeometryCollection(List<IGeometryObject> geometries)
+            : base()
         {
             if (geometries == null)
             {
@@ -49,78 +50,81 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(GeometryConverter))]
         public List<IGeometryObject> Geometries { get; private set; }
 
+        #region IEqualityComparer, IEquatable
+
         /// <summary>
-        /// Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// Determines whether the specified object is equal to the current object
         /// </summary>
-        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
-        /// </returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+            return Equals(this, obj as GeometryCollection);
+        }
 
-            if (ReferenceEquals(this, obj))
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(GeometryCollection other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(GeometryCollection left, GeometryCollection right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Geometries.SequenceEqual(right.Geometries);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(GeometryCollection left, GeometryCollection right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-
-            if (obj.GetType() != GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-
-            return Equals((GeometryCollection)obj);
+            return left.Equals(right);
         }
 
         /// <summary>
-        /// Returns a hash code for this instance.
+        /// Determines whether the specified object instances are not considered equal
         /// </summary>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
-        /// </returns>
-        public override int GetHashCode()
-        {
-            return Geometries.GetHashCode();
-        }
-
-        /// <summary>
-        /// Implements the operator ==.
-        /// </summary>
-        /// <param name="left">The left.</param>
-        /// <param name="right">The right.</param>
-        /// <returns>
-        /// The result of the operator.
-        /// </returns>
-        public static bool operator ==(GeometryCollection left, GeometryCollection right)
-        {
-            return Equals(left, right);
-        }
-
-        /// <summary>
-        /// Implements the operator !=.
-        /// </summary>
-        /// <param name="left">The left.</param>
-        /// <param name="right">The right.</param>
-        /// <returns>
-        /// The result of the operator.
-        /// </returns>
         public static bool operator !=(GeometryCollection left, GeometryCollection right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="GeometryCollection"/>, is equal to this instance.
+        /// Returns the hash code for this instance
         /// </summary>
-        /// <param name="other">The other.</param>
-        /// <returns></returns>
-        protected bool Equals(GeometryCollection other)
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Geometries.SequenceEqual(other.Geometries);
+            int hash = base.GetHashCode();
+            foreach (var item in Geometries)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(GeometryCollection other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/LineString.cs
+++ b/src/GeoJSON.Net/Geometry/LineString.cs
@@ -23,6 +23,7 @@ namespace GeoJSON.Net.Geometry
     {
         [JsonConstructor]
         protected internal LineString()
+            : base()
         {
         }
 
@@ -31,6 +32,7 @@ namespace GeoJSON.Net.Geometry
         /// </summary>
         /// <param name="coordinates">The coordinates.</param>
         public LineString(IEnumerable<IPosition> coordinates)
+            : base()
         {
             if (coordinates == null)
             {
@@ -57,31 +59,6 @@ namespace GeoJSON.Net.Geometry
         [JsonProperty(PropertyName = "coordinates", Required = Required.Always)]
         [JsonConverter(typeof(LineStringConverter))]
         public List<IPosition> Coordinates { get; set; }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
-
-            return Equals((LineString)obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
 
         /// <summary>
         ///     Determines whether this instance has its first and last coordinate at the same position and thereby is closed.
@@ -117,19 +94,81 @@ namespace GeoJSON.Net.Geometry
             return Coordinates.Count >= 4 && IsClosed();
         }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(this, obj as LineString);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(LineString other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(LineString left, LineString right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Coordinates.SequenceEqual(right.Coordinates);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
         public static bool operator ==(LineString left, LineString right)
         {
-            return Equals(left, right);
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(null, right))
+            {
+                return false;
+            }
+            return left.Equals(right);
         }
 
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(LineString left, LineString right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
-        protected bool Equals(LineString other)
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Coordinates.SequenceEqual(other.Coordinates);
+            int hash = base.GetHashCode();
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(LineString other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/MultiLineString.cs
+++ b/src/GeoJSON.Net/Geometry/MultiLineString.cs
@@ -11,19 +11,21 @@ using System.Collections.Generic;
 using System.Linq;
 using GeoJSON.Net.Converters;
 using Newtonsoft.Json;
+using System;
 
 namespace GeoJSON.Net.Geometry
 {
     /// <summary>
     ///     Defines the <see cref="http://geojson.org/geojson-spec.html#multilinestring">MultiLineString</see> type.
     /// </summary>
-    public class MultiLineString : GeoJSONObject, IGeometryObject
+    public class MultiLineString : GeoJSONObject, IGeometryObject, IEqualityComparer<MultiLineString>, IEquatable<MultiLineString>
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="MultiLineString" /> class.
         /// </summary>
         /// <param name="coordinates">The coordinates.</param>
         public MultiLineString(List<LineString> coordinates)
+            : base()
         {
             Coordinates = coordinates ?? new List<LineString>();
             Type = GeoJSONObjectType.MultiLineString;
@@ -37,44 +39,81 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(PolygonConverter))]
         public List<LineString> Coordinates { get; private set; }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+            return Equals(this, obj as MultiLineString);
+        }
 
-            if (ReferenceEquals(this, obj))
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(MultiLineString other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(MultiLineString left, MultiLineString right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Coordinates.SequenceEqual(right.Coordinates);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(MultiLineString left, MultiLineString right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-
-            if (obj.GetType() != GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-
-            return Equals((MultiLineString)obj);
+            return left.Equals(right);
         }
 
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
-
-        public static bool operator ==(MultiLineString left, MultiLineString right)
-        {
-            return Equals(left, right);
-        }
-
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(MultiLineString left, MultiLineString right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
-        protected bool Equals(MultiLineString other)
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Coordinates.SequenceEqual(other.Coordinates);
+            int hash = base.GetHashCode();
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(MultiLineString other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/MultiPoint.cs
+++ b/src/GeoJSON.Net/Geometry/MultiPoint.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GeoJSON.Net.Converters;
 using Newtonsoft.Json;
+using System;
 
 namespace GeoJSON.Net.Geometry
 {
@@ -18,13 +19,14 @@ namespace GeoJSON.Net.Geometry
     ///     Contains an array of <see cref="Point" />s.
     /// </summary>
     /// <seealso cref="http://geojson.org/geojson-spec.html#multipoint" />
-    public class MultiPoint : GeoJSONObject, IGeometryObject
+    public class MultiPoint : GeoJSONObject, IGeometryObject, IEqualityComparer<MultiPoint>, IEquatable<MultiPoint>
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="MultiPoint" /> class.
         /// </summary>
         /// <param name="coordinates">The coordinates.</param>
         public MultiPoint(List<Point> coordinates = null)
+            : base()
         {
             this.Coordinates = coordinates ?? new List<Point>();
             this.Type = GeoJSONObjectType.MultiPoint;
@@ -38,41 +40,81 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(MultiPointConverter))]
         public List<Point> Coordinates { get; private set; }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            return Equals(this, obj as MultiPoint);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(MultiPoint other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(MultiPoint left, MultiPoint right)
+        {
+            if (base.Equals(left, right))
             {
-                return false;
+                return left.Coordinates.SequenceEqual(right.Coordinates);
             }
-            if (ReferenceEquals(this, obj))
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(MultiPoint left, MultiPoint right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-            if (obj.GetType() != this.GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-            return Equals((MultiPoint)obj);
+            return left.Equals(right);
         }
 
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
-
-        public static bool operator ==(MultiPoint left, MultiPoint right)
-        {
-            return Equals(left, right);
-        }
-
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(MultiPoint left, MultiPoint right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
-        protected bool Equals(MultiPoint other)
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Coordinates.SequenceEqual(other.Coordinates);
+            int hash = base.GetHashCode();
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(MultiPoint other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/MultiPolygon.cs
+++ b/src/GeoJSON.Net/Geometry/MultiPolygon.cs
@@ -29,6 +29,7 @@ namespace GeoJSON.Net.Geometry
         /// </summary>
         /// <param name="polygons">The polygons contained in this MultiPolygon.</param>
         public MultiPolygon(List<Polygon> polygons)
+            : base()
         {
             if (polygons == null)
             {
@@ -46,44 +47,81 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(MultiPolygonConverter))]
         public List<Polygon> Coordinates { get; private set; }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+            return Equals(this, obj as MultiPolygon);
+        }
 
-            if (ReferenceEquals(this, obj))
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(MultiPolygon other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(MultiPolygon left, MultiPolygon right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Coordinates.SequenceEqual(right.Coordinates);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(MultiPolygon left, MultiPolygon right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-
-            if (obj.GetType() != GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-
-            return Equals((MultiPolygon)obj);
+            return left.Equals(right);
         }
 
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
-
-        public static bool operator ==(MultiPolygon left, MultiPolygon right)
-        {
-            return Equals(left, right);
-        }
-
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(MultiPolygon left, MultiPolygon right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
-        protected bool Equals(MultiPolygon other)
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Coordinates.SequenceEqual(other.Coordinates);
+            int hash = base.GetHashCode();
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(MultiPolygon other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/Point.cs
+++ b/src/GeoJSON.Net/Geometry/Point.cs
@@ -10,6 +10,7 @@
 using System;
 using GeoJSON.Net.Converters;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace GeoJSON.Net.Geometry
 {
@@ -17,16 +18,20 @@ namespace GeoJSON.Net.Geometry
     ///     In geography, a point refers to a Position on a map, expressed in latitude and longitude.
     /// </summary>
     /// <seealso cref="http://geojson.org/geojson-spec.html#point" />
-    public class Point : GeoJSONObject, IGeometryObject
+    public class Point : GeoJSONObject, IGeometryObject, IEqualityComparer<Point>, IEquatable<Point>
     {
         [JsonConstructor]
-        private Point() { }
+        private Point()
+                : base()
+        {
+        }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Point" /> class.
         /// </summary>
         /// <param name="coordinates">The Position.</param>
         public Point(IPosition coordinates)
+            : this()
         {
             if (coordinates == null)
             {
@@ -45,44 +50,78 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(PointConverter))]
         public IPosition Coordinates { get; set; }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+            return Equals(this, obj as Point);
+        }
 
-            if (ReferenceEquals(this, obj))
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(Point other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(Point left, Point right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Coordinates.Equals(right.Coordinates);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(Point left, Point right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-
-            if (obj.GetType() != GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-
-            return Equals((Point)obj);
+            return left.Equals(right);
         }
 
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
-
-        public static bool operator ==(Point left, Point right)
-        {
-            return Equals(left, right);
-        }
-
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(Point left, Point right)
         {
-            return !Equals(left, right);
+            return !(left == right);
+        }
+        
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
+        {
+            int hash = base.GetHashCode();
+            hash = (hash * 397) ^ Coordinates.GetHashCode();
+            return hash;
         }
 
-        protected bool Equals(Point other)
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(Point other)
         {
-            return base.Equals(other) && Coordinates.Equals(other.Coordinates);
+            return other.GetHashCode();
         }
+
+        #endregion
     }
 }

--- a/src/GeoJSON.Net/Geometry/Polygon.cs
+++ b/src/GeoJSON.Net/Geometry/Polygon.cs
@@ -56,44 +56,81 @@ namespace GeoJSON.Net.Geometry
         [JsonConverter(typeof(PolygonConverter))]
         public List<LineString> Coordinates { get; set; }
 
+        #region IEqualityComparer, IEquatable
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+            return Equals(this, obj as Polygon);
+        }
 
-            if (ReferenceEquals(this, obj))
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object
+        /// </summary>
+        public bool Equals(Polygon other)
+        {
+            return Equals(this, other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public bool Equals(Polygon left, Polygon right)
+        {
+            if (base.Equals(left, right))
+            {
+                return left.Coordinates.SequenceEqual(right.Coordinates);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instances are considered equal
+        /// </summary>
+        public static bool operator ==(Polygon left, Polygon right)
+        {
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
-
-            if (obj.GetType() != GetType())
+            if (ReferenceEquals(null, right))
             {
                 return false;
             }
-
-            return Equals((Polygon)obj);
+            return left.Equals(right);
         }
 
-        public override int GetHashCode()
-        {
-            return Coordinates.GetHashCode();
-        }
-
-        public static bool operator ==(Polygon left, Polygon right)
-        {
-            return Equals(left, right);
-        }
-
+        /// <summary>
+        /// Determines whether the specified object instances are not considered equal
+        /// </summary>
         public static bool operator !=(Polygon left, Polygon right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
-        protected bool Equals(Polygon other)
+        /// <summary>
+        /// Returns the hash code for this instance
+        /// </summary>
+        public override int GetHashCode()
         {
-            return base.Equals(other) && Coordinates.SequenceEqual(other.Coordinates);
+            int hash = base.GetHashCode();
+            foreach (var item in Coordinates)
+            {
+                hash = (hash * 397) ^ item.GetHashCode();
+            }
+            return hash;
         }
+
+        /// <summary>
+        /// Returns the hash code for the specified object
+        /// </summary>
+        public int GetHashCode(Polygon other)
+        {
+            return other.GetHashCode();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
The access modifiers on the Coordinates property of LineString, Point and Polygon are `get; set;`, while on all other Geometry objects the modifiers are `get; private set`. 
And yet the Coordinates property on LineString, Point and Polygon uses the coordinates to compute the hashcode. That means that if you accidentally change the Coordinates you can't lookup the object in a HashSet, if you changed the coordinates after adding it to the set.

The Equals GetHashCode contract states that 
1) If two objects equal, they must return the same hashcode
2) If two objects have the same hashcode, they may or may not be equal

You can see that the geometries does not adheres to this contract by adding the following test to the GeometryTests.cs in the current master branch

```
        [Test]
        [TestCaseSource(typeof(GeometryTests), nameof(Geometries))]
        public void Equals_GetHashCode_Contract(IGeometryObject geometry)
        {
            var classWithGeometry = new ClassWithGeometryProperty(geometry);

            var json = JsonConvert.SerializeObject(classWithGeometry);

            var deserializedClassWithGeometry = JsonConvert
                .DeserializeObject<ClassWithGeometryProperty>(json);

            Assert.AreEqual(
                classWithGeometry.Geometry, 
                deserializedClassWithGeometry.Geometry);

            Assert.AreEqual(
                classWithGeometry.Geometry.GetHashCode(), 
                deserializedClassWithGeometry.Geometry.GetHashCode());
        }
```

I think is that the reason for this is that the Equals methods on the Geometry objects are computed from the Coordinates.SequenceEqual method, which 
`Determines whether two sequences are equal by comparing the elements by using the default equality comparer for their type.`
The hash codes on the other hand are computed from Coordinates.GetHashCode(), but that returns a different hash code for each Coordinates instance, even if the contents of the coordinates are the same. 
It does however return identical hash codes if computed like this
```
        public override int GetHashCode()
        {
            int hash = base.GetHashCode();
            foreach (var item in Coordinates)
            {
                hash = (hash * 397) ^ item.GetHashCode();
            }
            return hash;
        }
```
I believe this pull request would fix that, and enable you to store geometries in hash sets.