### PR TITLE
remove feature.Id and Property comparison

### DIFF
--- a/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
@@ -158,7 +158,13 @@ namespace GeoJSON.Net.Tests.Feature
 
                 Assert.AreEqual(expectedId, actualId);
                 Assert.AreEqual(expectedIndex, actualIndex);
+
+                Assert.Inconclusive("not supported. the Feature.Id is optional. " + 
+                    " create a new class that inherits from" +
+                    " Feature and then override Equals and GetHashCode");
+
             }
+
         }
 
     }

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
@@ -357,16 +357,6 @@ namespace GeoJSON.Net.Tests.Feature
 
             Assert_Are_Not_Equal(left, right); // different geometries
 
-            left = new Net.Feature.Feature(new Point(
-                geometry_10),
-                leftDictionary,
-                "abc");
-            right = new Net.Feature.Feature(new Point(
-                geometry_20),
-                rightDictionary,
-                "xyz"); // different geometries and ids
-
-            Assert_Are_Not_Equal(left, right);
 
             left = new Net.Feature.Feature(new Point(
                 geometry_10),
@@ -375,44 +365,10 @@ namespace GeoJSON.Net.Tests.Feature
             right = new Net.Feature.Feature(new Point(
                 geometry_10),
                 rightDictionary,
-                "abc"); // identical except properties are in random order
+                "abc"); // identical geometries, different ids and or properties or not compared
 
             Assert_Are_Equal(left, right);
 
-            left = new Net.Feature.Feature(new Point(
-                geometry_10),
-                leftDictionary,
-                "abc");
-            right = new Net.Feature.Feature(new Point(
-                geometry_10),
-                rightDictionary,
-                "xyz"); // different ids
-
-            Assert_Are_Not_Equal(left, right);
-
-            leftDictionary.Add("Guid", Guid.NewGuid().ToString());
-
-            left = new Net.Feature.Feature(new Point(
-                geometry_10),
-                leftDictionary,
-                "abc");
-            right = new Net.Feature.Feature(new Point(
-                geometry_10),
-                rightDictionary,
-                "abc"); // different properties
-
-            Assert_Are_Not_Equal(left, right);
-
-            left = new Net.Feature.Feature(new Point(
-               geometry_10),
-               null,
-               "abc");
-            right = new Net.Feature.Feature(new Point(
-                geometry_10),
-                rightDictionary,
-                "abc"); // different properties
-
-            Assert_Are_Not_Equal(left, right);
         }
 
         [Test]
@@ -428,7 +384,7 @@ namespace GeoJSON.Net.Tests.Feature
             var rightJson = JsonConvert.SerializeObject(rightFeature);
             var right = JsonConvert.DeserializeObject<Net.Feature.Feature>(rightJson);
 
-            Assert_Are_Equal(left, right);
+            Assert_Are_Equal(left, right); 
 
             leftFeature = new Net.Feature.Feature(geometry, GetPropertiesInRandomOrder(), null);
             leftJson = JsonConvert.SerializeObject(leftFeature);
@@ -438,7 +394,17 @@ namespace GeoJSON.Net.Tests.Feature
             rightJson = JsonConvert.SerializeObject(rightFeature);
             right = JsonConvert.DeserializeObject<Net.Feature.Feature>(rightJson);
 
-            Assert_Are_Equal(left, right);
+            Assert_Are_Equal(left, right); // assert properties doesn't influence comparison and hashcode
+
+            leftFeature = new Net.Feature.Feature(geometry, null, "abc_abc");
+            leftJson = JsonConvert.SerializeObject(leftFeature);
+            left = JsonConvert.DeserializeObject<Net.Feature.Feature>(leftJson);
+            
+            rightFeature = new Net.Feature.Feature(geometry, null, "xyz_XYZ");
+            rightJson = JsonConvert.SerializeObject(rightFeature);
+            right = JsonConvert.DeserializeObject<Net.Feature.Feature>(rightJson);
+
+            Assert_Are_Equal(left, right); // assert id's doesn't influence comparison and hashcode
 
             leftFeature = new Net.Feature.Feature(geometry, GetPropertiesInRandomOrder(), "abc");
             leftJson = JsonConvert.SerializeObject(leftFeature);
@@ -448,7 +414,9 @@ namespace GeoJSON.Net.Tests.Feature
             rightJson = JsonConvert.SerializeObject(rightFeature);
             right = JsonConvert.DeserializeObject<Net.Feature.Feature>(rightJson);
 
-            Assert_Are_Equal(left, right);
+            Assert_Are_Equal(left, right); // assert id's + properties doesn't influence comparison and hashcode
+
+
 
         }
 

--- a/src/GeoJSON.Net/Feature/Feature.cs
+++ b/src/GeoJSON.Net/Feature/Feature.cs
@@ -154,14 +154,6 @@ namespace GeoJSON.Net.Feature
             {
                 hash = (hash * 397) ^ Geometry.GetHashCode();
             }
-            if (Properties != null && Properties.Count > 0)
-            {
-                hash = (hash * 397) ^ GetPropertiesHashCode(Properties);
-            }
-            if (Id != null)
-            {
-                hash = (hash * 397) ^ Id.GetHashCode();
-            }
             return hash;
         }
 
@@ -171,21 +163,6 @@ namespace GeoJSON.Net.Feature
         public int GetHashCode(Feature obj)
         {
             return obj.GetHashCode();
-        }
-
-        private int GetPropertiesHashCode(Dictionary<string, object> properties)
-        {
-            var keys = properties.Keys.OrderBy(k => k).ToList();
-            int hash = 1;
-            string hashString;
-            object value;
-            foreach (var key in keys)
-            {
-                value = properties[key];
-                hashString = (value == null) ? key : key + value.ToString();
-                hash = (hash * 397) ^ hashString.GetHashCode();
-            }
-            return hash;
         }
 
         #endregion


### PR DESCRIPTION
only Feature.Type, and the Feature.Geometry takes part in the comparison and hash code computation