### PR TITLE
Included Type property when DefaultValueHanding is set to Ignore

### DIFF
--- a/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
@@ -71,5 +71,16 @@ namespace GeoJSON.Net.Tests.Geometry
             Assert.AreEqual(expectedPoint.GetHashCode(), actualPoint.GetHashCode());
         }
 
+        [Test]
+        public void Can_Serialize_With_Lat_Lon_Alt_DefaultValueHandling_Ignore()
+        {
+            var point = new Point(new GeographicPosition(53.2455662, 90.65464646, 200.4567));
+
+            var expectedJson = "{\"coordinates\":[90.65464646,53.2455662,200.4567],\"type\":\"Point\"}";
+
+            var actualJson = JsonConvert.SerializeObject(point, new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore });
+
+            JsonAssert.AreEqual(expectedJson, actualJson);
+        }
     }
 }

--- a/src/GeoJSON.Net/GeoJSONObject.cs
+++ b/src/GeoJSON.Net/GeoJSONObject.cs
@@ -70,7 +70,7 @@ namespace GeoJSON.Net
         /// <value>
         ///     The type of the object.
         /// </value>
-        [JsonProperty(PropertyName = "type", Required = Required.Always)]
+        [JsonProperty(PropertyName = "type", Required = Required.Always, DefaultValueHandling = DefaultValueHandling.Include)]
         [JsonConverter(typeof(StringEnumConverter))]
         public GeoJSONObjectType Type { get; internal set; }
 

--- a/src/GeoJSON.Net/Geometry/Point.cs
+++ b/src/GeoJSON.Net/Geometry/Point.cs
@@ -35,7 +35,7 @@ namespace GeoJSON.Net.Geometry
         {
             if (coordinates == null)
             {
-                throw new ArgumentNullException("coordinates");
+                throw new ArgumentNullException(nameof(coordinates));
             }
 
             Coordinates = coordinates;
@@ -93,7 +93,7 @@ namespace GeoJSON.Net.Geometry
             {
                 return false;
             }
-            return left.Equals(right);
+            return left != null && left.Equals(right);
         }
 
         /// <summary>


### PR DESCRIPTION
#44 Included the Type property when DefaultValueHandling is set to Ignore as Point is the default value and it gets left off