### PR TITLE
Set specific version to false for Newtonsoft.Json

### DIFF
--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
I couldn't get assembly redirect to work for Newtonsoft.Json when another dependency needed version 9 of Newtonsoft.Json. This change solves my problem. Would this change be OK? I've run all unit tests with version 9.0.1 and they pass.