### PR TITLE
adds generic FeatureCollection

### DIFF
--- a/src/GeoJSON.Net/Features/Feature.cs
+++ b/src/GeoJSON.Net/Features/Feature.cs
@@ -12,14 +12,28 @@ using System;
 
 namespace GeoJSON.Net.Features
 {
-    /// <summary>
-    /// A GeoJSON Feature Object; generic version for strongly typed <see cref="Geometry"/>
-    /// and <see cref="Properties"/>
-    /// </summary>
-    /// <remarks>
-    /// See https://tools.ietf.org/html/rfc7946#section-3.2
-    /// </remarks>
-    public class Feature<TGeometry, TProps> : GeoJSONObject, IEquatable<Feature<TGeometry, TProps>>
+	/// <summary>
+	/// A GeoJSON Feature Object; generic version for strongly typed <see cref="Geometry"/>
+	/// and <see cref="Properties"/>
+	/// </summary>
+	/// <remarks>
+	/// See https://tools.ietf.org/html/rfc7946#section-3.2
+	/// </remarks>
+	public interface IFeature<out TGeometry, TProps> where TGeometry : IGeometryObject
+	{
+		string Id { get; }
+		TGeometry Geometry { get; }
+		TProps Properties { get; }
+	}
+
+	/// <summary>
+	/// A GeoJSON Feature Object; generic version for strongly typed <see cref="Geometry"/>
+	/// and <see cref="Properties"/>
+	/// </summary>
+	/// <remarks>
+	/// See https://tools.ietf.org/html/rfc7946#section-3.2
+	/// </remarks>
+	public class Feature<TGeometry, TProps> : GeoJSONObject, IFeature<TGeometry, TProps>, IEquatable<Feature<TGeometry, TProps>>
         where TGeometry : IGeometryObject
     {
         [JsonConstructor]

--- a/src/GeoJSON.Net/Features/FeatureCollection.cs
+++ b/src/GeoJSON.Net/Features/FeatureCollection.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Linq;
+using GeoJSON.Net.Geometry;
 
 namespace GeoJSON.Net.Features
 {
@@ -119,4 +120,114 @@ namespace GeoJSON.Net.Features
 
         #endregion
     }
+
+	public class FeatureCollection<TProps> : FeatureCollection, IEqualityComparer<FeatureCollection<TProps>>, IEquatable<FeatureCollection<TProps>>
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FeatureCollection" /> class.
+		/// </summary>
+		public FeatureCollection() : this(new List<IFeature<IGeometryObject, TProps>>())
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FeatureCollection" /> class.
+		/// </summary>
+		/// <param name="features">The features.</param>
+		public FeatureCollection(List<IFeature<IGeometryObject, TProps>> features)
+		{
+			if (features == null)
+			{
+				throw new ArgumentNullException(nameof(features));
+			}
+
+			Features = features;
+		}
+
+		public override GeoJSONObjectType Type => GeoJSONObjectType.FeatureCollection;
+
+		/// <summary>
+		/// Gets the features.
+		/// </summary>
+		/// <value>The features.</value>
+		[JsonProperty(PropertyName = "features", Required = Required.Always)]
+		new public List<IFeature<IGeometryObject, TProps>> Features { get; private set; }
+
+		#region IEqualityComparer, IEquatable
+
+		/// <summary>
+		/// Determines whether the specified object is equal to the current object
+		/// </summary>
+		public override bool Equals(object obj)
+		{
+			return Equals(this, obj as FeatureCollection<TProps>);
+		}
+
+		/// <summary>
+		/// Determines whether the specified object is equal to the current object
+		/// </summary>
+		public bool Equals(FeatureCollection<TProps> other)
+		{
+			return Equals(this, other);
+		}
+
+		/// <summary>
+		/// Determines whether the specified object instances are considered equal
+		/// </summary>
+		public bool Equals(FeatureCollection<TProps> left, FeatureCollection<TProps> right)
+		{
+			if (base.Equals(left, right))
+			{
+				return left.Features.SequenceEqual(right.Features);
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Determines whether the specified object instances are considered equal
+		/// </summary>
+		public static bool operator ==(FeatureCollection<TProps> left, FeatureCollection<TProps> right)
+		{
+			if (ReferenceEquals(left, right))
+			{
+				return true;
+			}
+			if (ReferenceEquals(null, right))
+			{
+				return false;
+			}
+			return left != null && left.Equals(right);
+		}
+
+		/// <summary>
+		/// Determines whether the specified object instances are not considered equal
+		/// </summary>
+		public static bool operator !=(FeatureCollection<TProps> left, FeatureCollection<TProps> right)
+		{
+			return !(left == right);
+		}
+
+		/// <summary>
+		/// Returns the hash code for this instance
+		/// </summary>
+		public override int GetHashCode()
+		{
+			int hash = base.GetHashCode();
+			foreach (var feature in Features)
+			{
+				hash = (hash * 397) ^ feature.GetHashCode();
+			}
+			return hash;
+		}
+
+		/// <summary>
+		/// Returns the hash code for the specified object
+		/// </summary>
+		public int GetHashCode(FeatureCollection<TProps> other)
+		{
+			return other.GetHashCode();
+		}
+
+		#endregion
+	}
 }


### PR DESCRIPTION
This PR adds a generic `FeatureCollection<TProps>` (and creates an interface for `Feature` to implement because `TGeometry` needs to be covariant). This enables the property objects in each feature to be directly serialized using JSON.NET instead of manually using a dictionary. See #104 for use-case.