### PR TITLE
Optimizations

### DIFF
--- a/src/GeoJSON.Net/CoordinateReferenceSystem/CRSBase.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/CRSBase.cs
@@ -74,11 +74,11 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
 
             foreach (var item in left.Properties)
             {
-                if (!right.Properties.ContainsKey(item.Key))
+                if (!right.Properties.TryGetValue(item.Key, out object rightValue))
                 {
                     return false;
                 }
-                if (!object.Equals(item.Value, right.Properties[item.Key]))
+                if (!object.Equals(item.Value, rightValue))
                 {
                     return false;
                 }

--- a/src/GeoJSON.Net/Feature/Feature.cs
+++ b/src/GeoJSON.Net/Feature/Feature.cs
@@ -190,7 +190,7 @@ namespace GeoJSON.Net.Feature
                 return false;
             }
 
-            return Geometry.Equals(other.Geometry);
+            return EqualityComparer<TGeometry>.Default.Equals(Geometry, other.Geometry);
         }
 
         public override bool Equals(object obj)

--- a/src/GeoJSON.Net/Geometry/LineString.cs
+++ b/src/GeoJSON.Net/Geometry/LineString.cs
@@ -68,7 +68,7 @@ namespace GeoJSON.Net.Geometry
 
             return firstCoordinate.Longitude.Equals(lastCoordinate.Longitude)
                    && firstCoordinate.Latitude.Equals(lastCoordinate.Latitude)
-                   && firstCoordinate.Altitude.Equals(lastCoordinate.Altitude);
+                   && Nullable.Equals(firstCoordinate.Altitude, lastCoordinate.Altitude);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is a few small optimizations.

* Replace `ContainsKey` + `[]` with a single `TryGetValue`
* Use `EqualityComparer<T>.Equals(T, T)` to avoid boxing, when `TGeometry` is a value type.
* Use `Nullable.Equals<T>(T?, T?)` to compare `Altitude` to avoid boxing `int?`. 