### PR TITLE
Fixes a bug with PositionConverter if pass interface instead of solid instantiation

### DIFF
--- a/src/GeoJSON.Net/Converters/PositionConverter.cs
+++ b/src/GeoJSON.Net/Converters/PositionConverter.cs
@@ -57,7 +57,7 @@ namespace GeoJSON.Net.Converters
         /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is Position coordinates)
+            if (value is IPosition coordinates)
             {
                 writer.WriteStartArray();
 


### PR DESCRIPTION
Single character change. I got an unexpected 'NotImplementedException' when one of my own classes implemented IPosition.