### PR TITLE
Geometry converter no longer writes.  It was causing a reference loop

### DIFF
--- a/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GeoJSON.Net.Converters;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -26,6 +27,31 @@ namespace GeoJSON.Net.Tests.Geometry
             var actualJson = JsonConvert.SerializeObject(polygon);
 
             JsonAssert.AreEqual(expectedJson, actualJson);
+        }
+
+        [Test]
+        public void Can_RoundTrip_IGeometryObject()
+        {
+            IGeometryObject polygon = new Polygon(new List<LineString>
+            {
+                new LineString(new List<IPosition>
+                {
+                    new Position(52.379790828551016, 5.3173828125),
+                    new Position(52.36721467920585, 5.456085205078125),
+                    new Position(52.303440474272755, 5.386047363281249, 4.23),
+                    new Position(52.379790828551016, 5.3173828125),
+                })
+            });
+
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                Converters = new List<JsonConverter>() { new GeometryConverter() }
+            };
+
+            var json = JsonConvert.SerializeObject(polygon, serializerSettings);
+            var result = JsonConvert.DeserializeObject<IGeometryObject>(json, serializerSettings);
+
+            Assert.AreEqual(result, polygon);
         }
 
         [Test]

--- a/src/GeoJSON.Net/Converters/GeometryConverter.cs
+++ b/src/GeoJSON.Net/Converters/GeometryConverter.cs
@@ -15,6 +15,8 @@ namespace GeoJSON.Net.Converters
     /// </summary>
     public class GeometryConverter : JsonConverter
     {
+        public override bool CanWrite => false;
+
         /// <summary>
         ///     Determines whether this instance can convert the specified object type.
         /// </summary>
@@ -64,7 +66,8 @@ namespace GeoJSON.Net.Converters
         /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            serializer.Serialize(writer, value);
+            // IGeometryObject can be written without a problem
+            throw new NotImplementedException("Unnecessary because CanWrite is false. The type will skip the converter.");
         }
 
         /// <summary>


### PR DESCRIPTION
Serializing Geometry using this converter resulted in:

```
Newtonsoft.Json.JsonSerializationException: Self referencing loop detected with type 'GeoJSON.Net.Geometry.Polygon'. Path ''
```

This PR fixes that.