### PR TITLE
Fix circular dependency issue

### DIFF
--- a/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
+++ b/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
@@ -8,13 +8,25 @@ namespace GeoJSON.Net.Tests.Serialization
     public class JsonTests
     {
         [Test]
-        public void Can_Serialize_as_GeoObject()
+        public void Can_Serialize_as_GeoJSONObject()
         {
             GeoJSONObject source = new Point(new Position(10, 20));
 
             var json = JsonConvert.SerializeObject(source, new GeoJsonConverter());
 
             var deserialized = JsonConvert.DeserializeObject<GeoJSONObject>(json, new GeoJsonConverter());
+
+            Assert.AreEqual(source, deserialized);
+        }
+
+        [Test]
+        public void Can_Serialize_as_IGeoJSONObject()
+        {
+            IGeoJSONObject source = new Point(new Position(10, 20));
+
+            var json = JsonConvert.SerializeObject(source, new GeoJsonConverter());
+
+            var deserialized = JsonConvert.DeserializeObject<IGeoJSONObject>(json, new GeoJsonConverter());
 
             Assert.AreEqual(source, deserialized);
         }

--- a/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
+++ b/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
@@ -1,0 +1,22 @@
+﻿using GeoJSON.Net.Converters;
+using GeoJSON.Net.Geometry;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace GeoJSON.Net.Tests.Serialization
+{
+    public class JsonTests
+    {
+        [Test]
+        public void Can_Serialize_as_GeoObject()
+        {
+            GeoJSONObject source = new Point(new Position(10, 20));
+
+            var json = JsonConvert.SerializeObject(source, new GeoJsonConverter());
+
+            var deserialized = JsonConvert.DeserializeObject<GeoJSONObject>(json, new GeoJsonConverter());
+
+            Assert.AreEqual(source, deserialized);
+        }
+    }
+}

--- a/src/GeoJSON.Net/Converters/GeoJsonConverter.cs
+++ b/src/GeoJSON.Net/Converters/GeoJsonConverter.cs
@@ -15,14 +15,16 @@ namespace GeoJSON.Net.Converters
 	/// </summary>
 	public class GeoJsonConverter : JsonConverter
 	{
-		/// <summary>
-		///     Determines whether this instance can convert the specified object type.
-		/// </summary>
-		/// <param name="objectType">Type of the object.</param>
-		/// <returns>
-		///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
-		/// </returns>
-		public override bool CanConvert(Type objectType)
+		public override bool CanWrite => false;
+
+        /// <summary>
+        ///     Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        ///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
 		{
 			return typeof(IGeoJSONObject).IsAssignableFromType(objectType);
 		}
@@ -64,7 +66,7 @@ namespace GeoJSON.Net.Converters
 		/// <param name="serializer">The calling serializer.</param>
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			serializer.Serialize(writer, value);
+			throw new NotSupportedException();
 		}
 
 		/// <summary>

--- a/src/GeoJSON.Net/Converters/GeoJsonConverter.cs
+++ b/src/GeoJSON.Net/Converters/GeoJsonConverter.cs
@@ -15,6 +15,7 @@ namespace GeoJSON.Net.Converters
 	/// </summary>
 	public class GeoJsonConverter : JsonConverter
 	{
+		/// <inheritdoc/>
 		public override bool CanWrite => false;
 
         /// <summary>


### PR DESCRIPTION
Currently when serializing an json object and the GeoJsonConverter is registered, JSON.NET detects a circular dependency, which would actually be a stackoverflow without this detection.

The solution is to turn it off for writing.