### PR TITLE
Add a working GitHub Actions config (for CI builds)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: |
+          3.1.x
+          5.0.x
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
       with:
         dotnet-version: 3.1.301
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build src/GeoJSON.Net.sln --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test src/GeoJSON.Net.sln --no-restore --verbosity normal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,11 @@ name: Build and Tests
 
 on:
   push:
-    branches: [ v2 ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ v2 ]
+    branches: [ '**' ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates the existing GHA config so that it triggers CI jobs for pushes to all branches and all PRs.

You can see a working GHA build based on this branch in my fork: https://github.com/janusw/GeoJSON.Net/actions/runs/7409092782

One can certainly add further extensions to this, but I'm deliberately sticking to the bare minimum that is necessary for triggering successful CI builds here (without any actual source-code changes), so that one has a baseline for further changes.

@xfischer @matt-lethargic Is this ok with you? 