### PR TITLE
GitHub Actions: upload nupkg as artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
@@ -23,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
-      run: dotnet build src/GeoJSON.Net.sln --configuration Release --no-restore
+      run: dotnet build src/GeoJSON.Net.sln -c Release --no-restore -p:Version=$(git describe --tags)
     - name: Test
       run: dotnet test src/GeoJSON.Net.sln --no-restore --verbosity normal
 
@@ -31,6 +33,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
@@ -40,6 +44,6 @@ jobs:
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
-      run: dotnet build src/GeoJSON.Net.sln --configuration Release --no-restore
+      run: dotnet build src/GeoJSON.Net.sln -c Release --no-restore -p:Version=$(git describe --tags)
     - name: Test
       run: dotnet test src/GeoJSON.Net.sln --no-restore --verbosity normal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
 
+  linuxBuild:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          3.1.x
+          5.0.x
+    - name: Install dependencies
+      run: dotnet restore src/GeoJSON.Net.sln
+    - name: Build
+      run: dotnet build src/GeoJSON.Net.sln --configuration Release --no-restore
+    - name: Test
+      run: dotnet test src/GeoJSON.Net.sln --no-restore --verbosity normal
 
+  winBuild:
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,10 @@ jobs:
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
       run: dotnet build src/GeoJSON.Net.sln -c Release --no-restore -p:Version=$(git describe --tags)
+    - name: Upload package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nupkg
+        path: ./src/GeoJSON.Net/bin/Release/*.nupkg
     - name: Test
       run: dotnet test src/GeoJSON.Net.sln --no-restore --verbosity normal


### PR DESCRIPTION
Note: I'm using `git describe --tags` to generate a unique version number for each package that is built. This scheme will also generate a proper version for a release, if the corresponding tag is set.
