### PR TITLE
Make Feature.geometry optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   linuxBuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup .NET Core
@@ -32,7 +32,7 @@ jobs:
   winBuild:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup .NET Core

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 *.csproj.user
 /TestResults
 .vscode
+.mono
 /GoCompare.CustomerPreference/CustomerPreferenceService/Service.xml
 /GoCompare.CustomerPreference/CustomerPreferenceService/Properties/PublishProfiles/CustomerPreferenceService - Web Deploy.pubxml
 /GoCompare.CustomerPreference/CustomerPreferenceService/Properties/PublishProfiles/CustomerPreferenceService - Web Deploy.pubxml.user

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
@@ -44,6 +44,38 @@ namespace GeoJSON.Net.Tests.Feature
         }
 
         [Test]
+        public void Can_Deserialize_Feature_With_Null_Geometry()
+        {
+            var json = GetExpectedJson();
+
+            var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
+
+            Assert.IsNotNull(feature);
+            Assert.IsNotNull(feature.Properties);
+            Assert.IsTrue(feature.Properties.Any());
+            Assert.IsTrue(feature.Properties.ContainsKey("name"));
+            Assert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+
+            Assert.IsNull(feature.Geometry);
+        }
+
+        [Test]
+        public void Can_Deserialize_Feature_Without_Geometry()
+        {
+            var json = GetExpectedJson();
+
+            var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
+
+            Assert.IsNotNull(feature);
+            Assert.IsNotNull(feature.Properties);
+            Assert.IsTrue(feature.Properties.Any());
+            Assert.IsTrue(feature.Properties.ContainsKey("name"));
+            Assert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+
+            Assert.IsNull(feature.Geometry);
+        }
+
+        [Test]
         public void Can_Serialize_LineString_Feature()
         {
             var coordinates = new[]

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests_Can_Deserialize_Feature_With_Null_Geometry.json
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests_Can_Deserialize_Feature_With_Null_Geometry.json
@@ -1,0 +1,7 @@
+﻿{
+  "type": "Feature",
+  "geometry": null,
+  "properties": {
+    "name": "Unlocalized Feature"
+  }
+}

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests_Can_Deserialize_Feature_Without_Geometry.json
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests_Can_Deserialize_Feature_Without_Geometry.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "Feature",
+  "properties": {
+    "name": "Unlocalized Feature"
+  }
+}

--- a/src/GeoJSON.Net/Feature/Feature.cs
+++ b/src/GeoJSON.Net/Feature/Feature.cs
@@ -35,7 +35,7 @@ namespace GeoJSON.Net.Feature
         [JsonProperty(PropertyName = "id", NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get; }
         
-        [JsonProperty(PropertyName = "geometry", Required = Required.AllowNull)]
+        [JsonProperty(PropertyName = "geometry", Required = Required.Default)]
         [JsonConverter(typeof(GeometryConverter))]
         public TGeometry Geometry { get; }
         


### PR DESCRIPTION
... in order to fix #178.

The fix itself is a one-liner, and I'm adding two test cases which verify that a feature without geometry member is deserialized the same way as a feature with null geometry.

Furthermore, I'm doing a small addition to .gitignore and fixing some deprecation warnings in the GitHub Actions build (by updating the `checkout` action to the latest stable version).

Any comments, @xfischer?