### PR TITLE
Update target frameworks and package dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          5.0.x
+        dotnet-version: '6.0.x'
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
@@ -38,9 +36,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          5.0.x
+        dotnet-version: '6.0.x'
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build
@@ -36,7 +36,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: dotnet restore src/GeoJSON.Net.sln
     - name: Build

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
@@ -3,7 +3,6 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -17,7 +16,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(collection);
 
-            ClassicAssert.IsTrue(!json.Contains("\"crs\""));
+            Assert.That(!json.Contains("\"crs\""));
         }
 
         [Test]
@@ -27,7 +26,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var point = JsonConvert.DeserializeObject<Point>(json);
 
-            ClassicAssert.IsNull(point.CRS);
+            Assert.That(point.CRS, Is.Null);
         }
 
         [Test]
@@ -37,8 +36,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var point = JsonConvert.DeserializeObject<Point>(json);
 
-            ClassicAssert.IsNotNull(point.CRS);
-            ClassicAssert.AreEqual(CRSType.Name, point.CRS.Type);
+            Assert.That(point.CRS, Is.Not.Null);
+            Assert.That(point.CRS.Type, Is.EqualTo(CRSType.Name));
         }
 
         [Test]
@@ -50,8 +49,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(point);
 
-            ClassicAssert.IsNotNull(json);
-            ClassicAssert.AreEqual(expected, json);
+            Assert.That(json, Is.Not.Null);
+            Assert.That(json, Is.EqualTo(expected));
         }
 
         [Test]
@@ -63,8 +62,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(point);
 
-            ClassicAssert.IsNotNull(json);
-            ClassicAssert.AreEqual(expected, json);
+            Assert.That(json, Is.Not.Null);
+            Assert.That(json, Is.EqualTo(expected));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/DefaultCrsTests.cs
@@ -3,6 +3,7 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -16,7 +17,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(collection);
 
-            Assert.IsTrue(!json.Contains("\"crs\""));
+            ClassicAssert.IsTrue(!json.Contains("\"crs\""));
         }
 
         [Test]
@@ -26,7 +27,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var point = JsonConvert.DeserializeObject<Point>(json);
 
-            Assert.IsNull(point.CRS);
+            ClassicAssert.IsNull(point.CRS);
         }
 
         [Test]
@@ -36,8 +37,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var point = JsonConvert.DeserializeObject<Point>(json);
 
-            Assert.IsNotNull(point.CRS);
-            Assert.AreEqual(CRSType.Name, point.CRS.Type);
+            ClassicAssert.IsNotNull(point.CRS);
+            ClassicAssert.AreEqual(CRSType.Name, point.CRS.Type);
         }
 
         [Test]
@@ -49,8 +50,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(point);
 
-            Assert.IsNotNull(json);
-            Assert.AreEqual(expected, json);
+            ClassicAssert.IsNotNull(json);
+            ClassicAssert.AreEqual(expected, json);
         }
 
         [Test]
@@ -62,8 +63,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 
             var json = JsonConvert.SerializeObject(point);
 
-            Assert.IsNotNull(json);
-            Assert.AreEqual(expected, json);
+            ClassicAssert.IsNotNull(json);
+            ClassicAssert.AreEqual(expected, json);
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
@@ -3,6 +3,7 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -15,7 +16,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         public void Has_Correct_Type()
         {
             var crs = new LinkedCRS(Href);
-            Assert.AreEqual(CRSType.Link, crs.Type);
+            ClassicAssert.AreEqual(CRSType.Link, crs.Type);
         }
 
         [Test]
@@ -23,8 +24,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         {
             var crs = new LinkedCRS(Href);
 
-            Assert.IsTrue(crs.Properties.ContainsKey("href"));
-            Assert.AreEqual(Href, crs.Properties["href"]);
+            ClassicAssert.IsTrue(crs.Properties.ContainsKey("href"));
+            ClassicAssert.AreEqual(Href, crs.Properties["href"]);
         }
 
         [Test]
@@ -33,8 +34,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             const string type = "ogcwkt";
             var crs = new LinkedCRS(Href, type);
 
-            Assert.IsTrue(crs.Properties.ContainsKey("type"));
-            Assert.AreEqual(type, crs.Properties["type"]);
+            ClassicAssert.IsTrue(crs.Properties.ContainsKey("type"));
+            ClassicAssert.AreEqual(type, crs.Properties["type"]);
         }
 
         [Test]
@@ -53,21 +54,21 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var pointWithCRS = JsonConvert.DeserializeObject<Point>(pointJson);
             var linkCRS = pointWithCRS.CRS as LinkedCRS;
 
-            Assert.IsNotNull(linkCRS);
-            Assert.AreEqual(CRSType.Link, linkCRS.Type);
-            Assert.AreEqual(Href, linkCRS.Properties["href"]);
+            ClassicAssert.IsNotNull(linkCRS);
+            ClassicAssert.AreEqual(CRSType.Link, linkCRS.Type);
+            ClassicAssert.AreEqual(Href, linkCRS.Properties["href"]);
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Href_String_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((string)null); });
+            ClassicAssert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((string)null); });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Href_Uri_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((Uri)null); });
+            ClassicAssert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((Uri)null); });
         }
 
         [Test]
@@ -84,20 +85,20 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en-US");
 #endif
 
-            var argumentExpection = Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS("http://not-a-valid-<>-url"); });
-            Assert.AreEqual(expected, argumentExpection.Message);
+            var argumentExpection = ClassicAssert.Throws<ArgumentException>(() => { var crs = new LinkedCRS("http://not-a-valid-<>-url"); });
+            ClassicAssert.AreEqual(expected, argumentExpection.Message);
         }
 
         [Test]
         public void Ctor_Does_Not_Throw_When_Href_Is_Dereferencable_Uri()
         {
-            Assert.DoesNotThrow(() => { var crs = new LinkedCRS("data.crs"); });
+            ClassicAssert.DoesNotThrow(() => { var crs = new LinkedCRS("data.crs"); });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Empty()
         {
-            Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS(string.Empty); });
+            ClassicAssert.Throws<ArgumentException>(() => { var crs = new LinkedCRS(string.Empty); });
         }
 
         [Test]
@@ -106,30 +107,30 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new LinkedCRS(Href);
             var right = new LinkedCRS(Href);
 
-            Assert.AreEqual(left, right);
+            ClassicAssert.AreEqual(left, right);
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(right.Equals(left));
 
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
 
             right = new LinkedCRS(Href + "?query=null");
 
-            Assert.AreNotEqual(left, right);
+            ClassicAssert.AreNotEqual(left, right);
 
-            Assert.IsFalse(left == right);
-            Assert.IsFalse(right == left);
+            ClassicAssert.IsFalse(left == right);
+            ClassicAssert.IsFalse(right == left);
 
-            Assert.IsFalse(left.Equals(right));
-            Assert.IsFalse(right.Equals(left));
+            ClassicAssert.IsFalse(left.Equals(right));
+            ClassicAssert.IsFalse(right.Equals(left));
 
-            Assert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/LinkedCRSTests.cs
@@ -3,7 +3,6 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -16,7 +15,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         public void Has_Correct_Type()
         {
             var crs = new LinkedCRS(Href);
-            ClassicAssert.AreEqual(CRSType.Link, crs.Type);
+            Assert.That(crs.Type, Is.EqualTo(CRSType.Link));
         }
 
         [Test]
@@ -24,8 +23,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         {
             var crs = new LinkedCRS(Href);
 
-            ClassicAssert.IsTrue(crs.Properties.ContainsKey("href"));
-            ClassicAssert.AreEqual(Href, crs.Properties["href"]);
+            Assert.That(crs.Properties.ContainsKey("href"));
+            Assert.That(crs.Properties["href"], Is.EqualTo(Href));
         }
 
         [Test]
@@ -34,8 +33,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             const string type = "ogcwkt";
             var crs = new LinkedCRS(Href, type);
 
-            ClassicAssert.IsTrue(crs.Properties.ContainsKey("type"));
-            ClassicAssert.AreEqual(type, crs.Properties["type"]);
+            Assert.That(crs.Properties.ContainsKey("type"));
+            Assert.That(crs.Properties["type"], Is.EqualTo(type));
         }
 
         [Test]
@@ -54,21 +53,21 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var pointWithCRS = JsonConvert.DeserializeObject<Point>(pointJson);
             var linkCRS = pointWithCRS.CRS as LinkedCRS;
 
-            ClassicAssert.IsNotNull(linkCRS);
-            ClassicAssert.AreEqual(CRSType.Link, linkCRS.Type);
-            ClassicAssert.AreEqual(Href, linkCRS.Properties["href"]);
+            Assert.That(linkCRS, Is.Not.Null);
+            Assert.That(linkCRS.Type, Is.EqualTo(CRSType.Link));
+            Assert.That(linkCRS.Properties["href"], Is.EqualTo(Href));
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Href_String_Is_Null()
         {
-            ClassicAssert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((string)null); });
+            Assert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((string)null); });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Href_Uri_Is_Null()
         {
-            ClassicAssert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((Uri)null); });
+            Assert.Throws<ArgumentNullException>(() => { var crs = new LinkedCRS((Uri)null); });
         }
 
         [Test]
@@ -85,20 +84,20 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en-US");
 #endif
 
-            var argumentExpection = ClassicAssert.Throws<ArgumentException>(() => { var crs = new LinkedCRS("http://not-a-valid-<>-url"); });
-            ClassicAssert.AreEqual(expected, argumentExpection.Message);
+            var argumentExpection = Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS("http://not-a-valid-<>-url"); });
+            Assert.That(argumentExpection.Message, Is.EqualTo(expected));
         }
 
         [Test]
         public void Ctor_Does_Not_Throw_When_Href_Is_Dereferencable_Uri()
         {
-            ClassicAssert.DoesNotThrow(() => { var crs = new LinkedCRS("data.crs"); });
+            Assert.DoesNotThrow(() => { var crs = new LinkedCRS("data.crs"); });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Empty()
         {
-            ClassicAssert.Throws<ArgumentException>(() => { var crs = new LinkedCRS(string.Empty); });
+            Assert.Throws<ArgumentException>(() => { var crs = new LinkedCRS(string.Empty); });
         }
 
         [Test]
@@ -107,30 +106,30 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new LinkedCRS(Href);
             var right = new LinkedCRS(Href);
 
-            ClassicAssert.AreEqual(left, right);
+            Assert.That(right, Is.EqualTo(left));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(right.Equals(left));
+            Assert.That(left.Equals(right));
+            Assert.That(right.Equals(left));
 
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
 
             right = new LinkedCRS(Href + "?query=null");
 
-            ClassicAssert.AreNotEqual(left, right);
+            Assert.That(right, Is.Not.EqualTo(left));
 
-            ClassicAssert.IsFalse(left == right);
-            ClassicAssert.IsFalse(right == left);
+            Assert.That(left == right, Is.False);
+            Assert.That(right == left, Is.False);
 
-            ClassicAssert.IsFalse(left.Equals(right));
-            ClassicAssert.IsFalse(right.Equals(left));
+            Assert.That(left.Equals(right), Is.False);
+            Assert.That(right.Equals(left), Is.False);
 
-            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.Not.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
@@ -3,7 +3,6 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Feature;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -16,7 +15,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var name = "EPSG:31370";
             var crs = new NamedCRS(name);
 
-            ClassicAssert.AreEqual(CRSType.Name, crs.Type);
+            Assert.That(crs.Type, Is.EqualTo(CRSType.Name));
         }
 
         [Test]
@@ -25,8 +24,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var name = "EPSG:31370";
             var crs = new NamedCRS(name);
 
-            ClassicAssert.IsTrue(crs.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual(name, crs.Properties["name"]);
+            Assert.That(crs.Properties.ContainsKey("name"));
+            Assert.That(crs.Properties["name"], Is.EqualTo(name));
         }
 
         [Test]
@@ -41,13 +40,13 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Null()
         {
-            ClassicAssert.Throws<ArgumentNullException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(null) }; });
+            Assert.Throws<ArgumentNullException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(null) }; });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Empty()
         {
-            ClassicAssert.Throws<ArgumentException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(string.Empty) }; });
+            Assert.Throws<ArgumentException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(string.Empty) }; });
         }
 
         [Test]
@@ -58,31 +57,31 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new NamedCRS(name);
             var right = new NamedCRS(name);
 
-            ClassicAssert.AreEqual(left, right);
+            Assert.That(right, Is.EqualTo(left));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(right.Equals(left));
+            Assert.That(left.Equals(right));
+            Assert.That(right.Equals(left));
 
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
 
             name = "EPSG:25832";
             right = new NamedCRS(name);
 
-            ClassicAssert.AreNotEqual(left, right);
+            Assert.That(right, Is.Not.EqualTo(left));
 
-            ClassicAssert.IsFalse(left == right);
-            ClassicAssert.IsFalse(right == left);
+            Assert.That(left == right, Is.False);
+            Assert.That(right == left, Is.False);
 
-            ClassicAssert.IsFalse(left.Equals(right));
-            ClassicAssert.IsFalse(right.Equals(left));
+            Assert.That(left.Equals(right), Is.False);
+            Assert.That(right.Equals(left), Is.False);
 
-            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.Not.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/NamedCrsTests.cs
@@ -3,6 +3,7 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Feature;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -15,7 +16,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var name = "EPSG:31370";
             var crs = new NamedCRS(name);
 
-            Assert.AreEqual(CRSType.Name, crs.Type);
+            ClassicAssert.AreEqual(CRSType.Name, crs.Type);
         }
 
         [Test]
@@ -24,8 +25,8 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var name = "EPSG:31370";
             var crs = new NamedCRS(name);
 
-            Assert.IsTrue(crs.Properties.ContainsKey("name"));
-            Assert.AreEqual(name, crs.Properties["name"]);
+            ClassicAssert.IsTrue(crs.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual(name, crs.Properties["name"]);
         }
 
         [Test]
@@ -40,13 +41,13 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(null) }; });
+            ClassicAssert.Throws<ArgumentNullException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(null) }; });
         }
 
         [Test]
         public void Ctor_Throws_ArgumentNullExpection_When_Name_Is_Empty()
         {
-            Assert.Throws<ArgumentException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(string.Empty) }; });
+            ClassicAssert.Throws<ArgumentException>(() => { var collection = new FeatureCollection() { CRS = new NamedCRS(string.Empty) }; });
         }
 
         [Test]
@@ -57,31 +58,31 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new NamedCRS(name);
             var right = new NamedCRS(name);
 
-            Assert.AreEqual(left, right);
+            ClassicAssert.AreEqual(left, right);
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(right.Equals(left));
 
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
 
             name = "EPSG:25832";
             right = new NamedCRS(name);
 
-            Assert.AreNotEqual(left, right);
+            ClassicAssert.AreNotEqual(left, right);
 
-            Assert.IsFalse(left == right);
-            Assert.IsFalse(right == left);
+            ClassicAssert.IsFalse(left == right);
+            ClassicAssert.IsFalse(right == left);
 
-            Assert.IsFalse(left.Equals(right));
-            Assert.IsFalse(right.Equals(left));
+            ClassicAssert.IsFalse(left.Equals(right));
+            ClassicAssert.IsFalse(right.Equals(left));
 
-            Assert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
@@ -2,6 +2,7 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Feature;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -13,7 +14,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         {
             var crs = new UnspecifiedCRS();
 
-            Assert.AreEqual(CRSType.Unspecified, crs.Type);
+            ClassicAssert.AreEqual(CRSType.Unspecified, crs.Type);
         }
 
         [Test]
@@ -32,7 +33,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var json = "{\"type\":\"FeatureCollection\",\"crs\":null,\"features\":[] }";
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(json);
 
-            Assert.IsInstanceOf<UnspecifiedCRS>(featureCollection.CRS);
+            ClassicAssert.IsInstanceOf<UnspecifiedCRS>(featureCollection.CRS);
         }
 
         [Test]
@@ -41,18 +42,18 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new UnspecifiedCRS();
             var right = new UnspecifiedCRS();
 
-            Assert.AreEqual(left, right);
+            ClassicAssert.AreEqual(left, right);
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(right.Equals(left));
 
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
+++ b/src/GeoJSON.Net.Tests/CoordinateReferenceSystem/UnspecifiedCRSTests.cs
@@ -2,7 +2,6 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Feature;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
 {
@@ -14,7 +13,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
         {
             var crs = new UnspecifiedCRS();
 
-            ClassicAssert.AreEqual(CRSType.Unspecified, crs.Type);
+            Assert.That(crs.Type, Is.EqualTo(CRSType.Unspecified));
         }
 
         [Test]
@@ -23,7 +22,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var collection = new FeatureCollection { CRS = new UnspecifiedCRS() };
             var expectedJson = "{\"type\":\"FeatureCollection\",\"crs\":null,\"features\":[] }";
             var actualJson = JsonConvert.SerializeObject(collection);
-            
+
             JsonAssert.AreEqual(expectedJson, actualJson);
         }
 
@@ -33,7 +32,7 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var json = "{\"type\":\"FeatureCollection\",\"crs\":null,\"features\":[] }";
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(json);
 
-            ClassicAssert.IsInstanceOf<UnspecifiedCRS>(featureCollection.CRS);
+            Assert.That(featureCollection.CRS, Is.InstanceOf<UnspecifiedCRS>());
         }
 
         [Test]
@@ -42,18 +41,18 @@ namespace GeoJSON.Net.Tests.CoordinateReferenceSystem
             var left = new UnspecifiedCRS();
             var right = new UnspecifiedCRS();
 
-            ClassicAssert.AreEqual(left, right);
+            Assert.That(right, Is.EqualTo(left));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(right.Equals(left));
+            Assert.That(left.Equals(right));
+            Assert.That(right.Equals(left));
 
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
@@ -5,6 +5,7 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Feature
 {
@@ -14,7 +15,7 @@ namespace GeoJSON.Net.Tests.Feature
         [Test]
         public void Ctor_Throws_ArgumentNullException_When_Features_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            ClassicAssert.Throws<ArgumentNullException>(() =>
             {
                 var featureCollection = new FeatureCollection(null);
             });
@@ -27,12 +28,12 @@ namespace GeoJSON.Net.Tests.Feature
 
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(json);
 
-            Assert.IsNotNull(featureCollection);
-            Assert.IsNotNull(featureCollection.Features);
-            Assert.AreEqual(featureCollection.Features.Count, 3);
-            Assert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Point), 1);
-            Assert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.MultiPolygon), 1);
-            Assert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Polygon), 1);
+            ClassicAssert.IsNotNull(featureCollection);
+            ClassicAssert.IsNotNull(featureCollection.Features);
+            ClassicAssert.AreEqual(featureCollection.Features.Count, 3);
+            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Point), 1);
+            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.MultiPolygon), 1);
+            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Polygon), 1);
         }
         
         [Test]
@@ -42,11 +43,11 @@ namespace GeoJSON.Net.Tests.Feature
 
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection<FeatureCollectionTestPropertyObject>>(json);
 
-            Assert.IsNotNull(featureCollection);
-            Assert.IsNotNull(featureCollection.Features);
-            Assert.AreEqual(featureCollection.Features.Count, 3);
-            Assert.AreEqual("DD", featureCollection.Features.First().Properties.Name);
-            Assert.AreEqual(123, featureCollection.Features.First().Properties.Size);
+            ClassicAssert.IsNotNull(featureCollection);
+            ClassicAssert.IsNotNull(featureCollection.Features);
+            ClassicAssert.AreEqual(featureCollection.Features.Count, 3);
+            ClassicAssert.AreEqual("DD", featureCollection.Features.First().Properties.Name);
+            ClassicAssert.AreEqual(123, featureCollection.Features.First().Properties.Size);
         }
         
         
@@ -75,9 +76,9 @@ namespace GeoJSON.Net.Tests.Feature
 
             var actualJson = JsonConvert.SerializeObject(model);
 
-            Assert.IsNotNull(actualJson);
+            ClassicAssert.IsNotNull(actualJson);
 
-            Assert.IsFalse(string.IsNullOrEmpty(actualJson));
+            ClassicAssert.IsFalse(string.IsNullOrEmpty(actualJson));
         }
         
         [Test]
@@ -138,10 +139,10 @@ namespace GeoJSON.Net.Tests.Feature
                 var expectedId = expectedIds[i];
                 var expectedIndex = expectedIndexes[i];
 
-                Assert.AreEqual(expectedId, actualId);
-                Assert.AreEqual(expectedIndex, actualIndex);
+                ClassicAssert.AreEqual(expectedId, actualId);
+                ClassicAssert.AreEqual(expectedIndex, actualIndex);
 
-                Assert.Inconclusive("not supported. the Feature.Id is optional. " + 
+                ClassicAssert.Inconclusive("not supported. the Feature.Id is optional. " + 
                     " create a new class that inherits from" +
                     " Feature and then override Equals and GetHashCode");
 
@@ -171,21 +172,21 @@ namespace GeoJSON.Net.Tests.Feature
 
         private void Assert_Are_Equal(FeatureCollection left, FeatureCollection right)
         {
-            Assert.AreEqual(left, right);
+            ClassicAssert.AreEqual(left, right);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(right.Equals(left));
 
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.IsFalse(left != right);
-            Assert.IsFalse(right != left);
+            ClassicAssert.IsFalse(left != right);
+            ClassicAssert.IsFalse(right != left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
     

--- a/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureCollectionTests.cs
@@ -5,7 +5,6 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Feature
 {
@@ -15,7 +14,7 @@ namespace GeoJSON.Net.Tests.Feature
         [Test]
         public void Ctor_Throws_ArgumentNullException_When_Features_Is_Null()
         {
-            ClassicAssert.Throws<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 var featureCollection = new FeatureCollection(null);
             });
@@ -28,12 +27,12 @@ namespace GeoJSON.Net.Tests.Feature
 
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(json);
 
-            ClassicAssert.IsNotNull(featureCollection);
-            ClassicAssert.IsNotNull(featureCollection.Features);
-            ClassicAssert.AreEqual(featureCollection.Features.Count, 3);
-            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Point), 1);
-            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.MultiPolygon), 1);
-            ClassicAssert.AreEqual(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Polygon), 1);
+            Assert.That(featureCollection, Is.Not.Null);
+            Assert.That(featureCollection.Features, Is.Not.Null);
+            Assert.That(featureCollection.Features.Count, Is.EqualTo(3));
+            Assert.That(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Point), Is.EqualTo(1));
+            Assert.That(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.MultiPolygon), Is.EqualTo(1));
+            Assert.That(featureCollection.Features.Count(x => x.Geometry.Type == GeoJSONObjectType.Polygon), Is.EqualTo(1));
         }
         
         [Test]
@@ -43,11 +42,11 @@ namespace GeoJSON.Net.Tests.Feature
 
             var featureCollection = JsonConvert.DeserializeObject<FeatureCollection<FeatureCollectionTestPropertyObject>>(json);
 
-            ClassicAssert.IsNotNull(featureCollection);
-            ClassicAssert.IsNotNull(featureCollection.Features);
-            ClassicAssert.AreEqual(featureCollection.Features.Count, 3);
-            ClassicAssert.AreEqual("DD", featureCollection.Features.First().Properties.Name);
-            ClassicAssert.AreEqual(123, featureCollection.Features.First().Properties.Size);
+            Assert.That(featureCollection, Is.Not.Null);
+            Assert.That(featureCollection.Features, Is.Not.Null);
+            Assert.That(featureCollection.Features.Count, Is.EqualTo(3));
+            Assert.That(featureCollection.Features.First().Properties.Name, Is.EqualTo("DD"));
+            Assert.That(featureCollection.Features.First().Properties.Size, Is.EqualTo(123));
         }
         
         
@@ -76,9 +75,9 @@ namespace GeoJSON.Net.Tests.Feature
 
             var actualJson = JsonConvert.SerializeObject(model);
 
-            ClassicAssert.IsNotNull(actualJson);
+            Assert.That(actualJson, Is.Not.Null);
 
-            ClassicAssert.IsFalse(string.IsNullOrEmpty(actualJson));
+            Assert.That(string.IsNullOrEmpty(actualJson), Is.False);
         }
         
         [Test]
@@ -139,10 +138,10 @@ namespace GeoJSON.Net.Tests.Feature
                 var expectedId = expectedIds[i];
                 var expectedIndex = expectedIndexes[i];
 
-                ClassicAssert.AreEqual(expectedId, actualId);
-                ClassicAssert.AreEqual(expectedIndex, actualIndex);
+                Assert.That(actualId, Is.EqualTo(expectedId));
+                Assert.That(actualIndex, Is.EqualTo(expectedIndex));
 
-                ClassicAssert.Inconclusive("not supported. the Feature.Id is optional. " + 
+                Assert.Inconclusive("not supported. the Feature.Id is optional. " + 
                     " create a new class that inherits from" +
                     " Feature and then override Equals and GetHashCode");
 
@@ -172,21 +171,21 @@ namespace GeoJSON.Net.Tests.Feature
 
         private void Assert_Are_Equal(FeatureCollection left, FeatureCollection right)
         {
-            ClassicAssert.AreEqual(left, right);
+            Assert.That(right, Is.EqualTo(left));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(right.Equals(left));
+            Assert.That(left.Equals(right));
+            Assert.That(right.Equals(left));
 
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.IsFalse(left != right);
-            ClassicAssert.IsFalse(right != left);
+            Assert.That(left != right, Is.False);
+            Assert.That(right != left, Is.False);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
     

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
@@ -1,6 +1,7 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,16 +18,16 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Any());
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Any());
 
-            Assert.IsTrue(feature.Properties.ContainsKey("name"));
-            Assert.AreEqual(feature.Properties["name"], "Dinagat Islands");
+            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual(feature.Properties["name"], "Dinagat Islands");
 
-            Assert.AreEqual("test-id", feature.Id);
+            ClassicAssert.AreEqual("test-id", feature.Id);
 
-            Assert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
+            ClassicAssert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
         }
 
         [Test]
@@ -36,11 +37,11 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsEmpty(feature.Properties);
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsEmpty(feature.Properties);
 
-            Assert.AreEqual(GeoJSONObjectType.Polygon, feature.Geometry.Type);
+            ClassicAssert.AreEqual(GeoJSONObjectType.Polygon, feature.Geometry.Type);
         }
 
         [Test]
@@ -50,13 +51,13 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Any());
-            Assert.IsTrue(feature.Properties.ContainsKey("name"));
-            Assert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Any());
+            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
 
-            Assert.IsNull(feature.Geometry);
+            ClassicAssert.IsNull(feature.Geometry);
         }
 
         [Test]
@@ -66,13 +67,13 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Any());
-            Assert.IsTrue(feature.Properties.ContainsKey("name"));
-            Assert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Any());
+            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
 
-            Assert.IsNull(feature.Geometry);
+            ClassicAssert.IsNull(feature.Geometry);
         }
 
         [Test]
@@ -231,7 +232,7 @@ namespace GeoJSON.Net.Tests.Feature
             var expectedJson = this.GetExpectedJson();
             var actualJson = JsonConvert.SerializeObject(feature);
 
-            Assert.False(string.IsNullOrEmpty(expectedJson));
+            ClassicAssert.False(string.IsNullOrEmpty(expectedJson));
             JsonAssert.AreEqual(expectedJson, actualJson);
         }
 
@@ -250,9 +251,9 @@ namespace GeoJSON.Net.Tests.Feature
 
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), properties);
 
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Count > 1);
-            Assert.AreEqual(feature.Properties.Count, 6);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Count > 1);
+            ClassicAssert.AreEqual(feature.Properties.Count, 6);
         }
 
         [Test]
@@ -272,9 +273,9 @@ namespace GeoJSON.Net.Tests.Feature
 
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), properties);
 
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Count > 1);
-            Assert.AreEqual(
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Count > 1);
+            ClassicAssert.AreEqual(
                 feature.Properties.Count,
                 expectedProperties,
                 $"Expected: {expectedProperties} Actual: {feature.Properties.Count}");
@@ -285,7 +286,7 @@ namespace GeoJSON.Net.Tests.Feature
         {
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), (object)null);
 
-            Assert.IsNotNull(feature.Properties);
+            ClassicAssert.IsNotNull(feature.Properties);
             CollectionAssert.IsEmpty(feature.Properties);
         }
 
@@ -408,14 +409,14 @@ namespace GeoJSON.Net.Tests.Feature
             bool equal2 = true;
 
             var feature = new Net.Feature.Feature(new Point(new Position(12, 123)));
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature.Equals(null);
                 equal2 = feature == null;
             });
 
-            Assert.IsFalse(equal1);
-            Assert.IsFalse(equal2);
+            ClassicAssert.IsFalse(equal1);
+            ClassicAssert.IsFalse(equal2);
         }
 
         [Test]
@@ -424,12 +425,12 @@ namespace GeoJSON.Net.Tests.Feature
             var equal1 = true;
 
             Net.Feature.Feature feature = null;
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature != null;
             });
 
-            Assert.IsFalse(equal1);
+            ClassicAssert.IsFalse(equal1);
         }
 
         [Test]
@@ -439,14 +440,14 @@ namespace GeoJSON.Net.Tests.Feature
             bool equal2 = false;
 
             var feature = new Net.Feature.Feature(new Point(new Position(12, 123)));
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature == feature;
                 equal2 = feature.Equals(feature);
             });
 
-            Assert.IsTrue(equal1);
-            Assert.IsTrue(equal2);
+            ClassicAssert.IsTrue(equal1);
+            ClassicAssert.IsTrue(equal2);
         }
 
         [Test]
@@ -458,14 +459,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(null);
             var feature2 = new Net.Feature.Feature(new Point(new Position(12, 123)));
 
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            Assert.IsFalse(equal1);
-            Assert.IsFalse(equal2);
+            ClassicAssert.IsFalse(equal1);
+            ClassicAssert.IsFalse(equal2);
         }
 
         [Test]
@@ -477,14 +478,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(new Point(new Position(12, 123)));
             var feature2 = new Net.Feature.Feature(null);
 
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            Assert.IsFalse(equal1);
-            Assert.IsFalse(equal2);
+            ClassicAssert.IsFalse(equal1);
+            ClassicAssert.IsFalse(equal2);
         }
 
         [Test]
@@ -496,14 +497,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(null);
             var feature2 = new Net.Feature.Feature(null);
 
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            Assert.IsTrue(equal1);
-            Assert.IsTrue(equal2);
+            ClassicAssert.IsTrue(equal1);
+            ClassicAssert.IsTrue(equal2);
         }
 
 
@@ -553,37 +554,37 @@ namespace GeoJSON.Net.Tests.Feature
 
         private void Assert_Are_Equal(Net.Feature.Feature left, Net.Feature.Feature right)
         {
-            Assert.AreEqual(left, right);
+            ClassicAssert.AreEqual(left, right);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(right.Equals(left));
 
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.IsFalse(left != right);
-            Assert.IsFalse(right != left);
+            ClassicAssert.IsFalse(left != right);
+            ClassicAssert.IsFalse(right != left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
 
         private void Assert_Are_Not_Equal(Net.Feature.Feature left, Net.Feature.Feature right)
         {
-            Assert.AreNotEqual(left, right);
+            ClassicAssert.AreNotEqual(left, right);
 
-            Assert.IsFalse(left.Equals(right));
-            Assert.IsFalse(right.Equals(left));
+            ClassicAssert.IsFalse(left.Equals(right));
+            ClassicAssert.IsFalse(right.Equals(left));
 
-            Assert.IsFalse(left == right);
-            Assert.IsFalse(right == left);
+            ClassicAssert.IsFalse(left == right);
+            ClassicAssert.IsFalse(right == left);
 
-            Assert.IsTrue(left != right);
-            Assert.IsTrue(right != left);
+            ClassicAssert.IsTrue(left != right);
+            ClassicAssert.IsTrue(right != left);
 
-            Assert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/FeatureTests.cs
@@ -1,10 +1,9 @@
-using GeoJSON.Net.Geometry;
-using Newtonsoft.Json;
-using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GeoJSON.Net.Geometry;
+using Newtonsoft.Json;
+using NUnit.Framework;
 
 namespace GeoJSON.Net.Tests.Feature
 {
@@ -18,16 +17,16 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Any());
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Any());
 
-            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual(feature.Properties["name"], "Dinagat Islands");
+            Assert.That(feature.Properties.ContainsKey("name"));
+            Assert.That(feature.Properties["name"], Is.EqualTo("Dinagat Islands"));
 
-            ClassicAssert.AreEqual("test-id", feature.Id);
+            Assert.That(feature.Id, Is.EqualTo("test-id"));
 
-            ClassicAssert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
+            Assert.That(feature.Geometry.Type, Is.EqualTo(GeoJSONObjectType.Point));
         }
 
         [Test]
@@ -37,11 +36,11 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsEmpty(feature.Properties);
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Empty);
 
-            ClassicAssert.AreEqual(GeoJSONObjectType.Polygon, feature.Geometry.Type);
+            Assert.That(feature.Geometry.Type, Is.EqualTo(GeoJSONObjectType.Polygon));
         }
 
         [Test]
@@ -51,13 +50,13 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Any());
-            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Any());
+            Assert.That(feature.Properties.ContainsKey("name"));
+            Assert.That(feature.Properties["name"], Is.EqualTo("Unlocalized Feature"));
 
-            ClassicAssert.IsNull(feature.Geometry);
+            Assert.That(feature.Geometry, Is.Null);
         }
 
         [Test]
@@ -67,13 +66,13 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Net.Feature.Feature>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Any());
-            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual(feature.Properties["name"], "Unlocalized Feature");
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Any());
+            Assert.That(feature.Properties.ContainsKey("name"));
+            Assert.That(feature.Properties["name"], Is.EqualTo("Unlocalized Feature"));
 
-            ClassicAssert.IsNull(feature.Geometry);
+            Assert.That(feature.Geometry, Is.Null);
         }
 
         [Test]
@@ -232,7 +231,7 @@ namespace GeoJSON.Net.Tests.Feature
             var expectedJson = this.GetExpectedJson();
             var actualJson = JsonConvert.SerializeObject(feature);
 
-            ClassicAssert.False(string.IsNullOrEmpty(expectedJson));
+            Assert.That(string.IsNullOrEmpty(expectedJson), Is.False);
             JsonAssert.AreEqual(expectedJson, actualJson);
         }
 
@@ -251,9 +250,9 @@ namespace GeoJSON.Net.Tests.Feature
 
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), properties);
 
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Count > 1);
-            ClassicAssert.AreEqual(feature.Properties.Count, 6);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Count > 1);
+            Assert.That(feature.Properties.Count, Is.EqualTo(6));
         }
 
         [Test]
@@ -273,11 +272,10 @@ namespace GeoJSON.Net.Tests.Feature
 
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), properties);
 
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Count > 1);
-            ClassicAssert.AreEqual(
-                feature.Properties.Count,
-                expectedProperties,
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Count > 1);
+            Assert.That(
+                expectedProperties, Is.EqualTo(feature.Properties.Count),
                 $"Expected: {expectedProperties} Actual: {feature.Properties.Count}");
         }
 
@@ -286,8 +284,8 @@ namespace GeoJSON.Net.Tests.Feature
         {
             Net.Feature.Feature feature = new Net.Feature.Feature(new Point(new Position(10, 10)), (object)null);
 
-            ClassicAssert.IsNotNull(feature.Properties);
-            CollectionAssert.IsEmpty(feature.Properties);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Empty);
         }
 
         [Test]
@@ -409,14 +407,14 @@ namespace GeoJSON.Net.Tests.Feature
             bool equal2 = true;
 
             var feature = new Net.Feature.Feature(new Point(new Position(12, 123)));
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature.Equals(null);
                 equal2 = feature == null;
             });
 
-            ClassicAssert.IsFalse(equal1);
-            ClassicAssert.IsFalse(equal2);
+            Assert.That(equal1, Is.False);
+            Assert.That(equal2, Is.False);
         }
 
         [Test]
@@ -425,12 +423,12 @@ namespace GeoJSON.Net.Tests.Feature
             var equal1 = true;
 
             Net.Feature.Feature feature = null;
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature != null;
             });
 
-            ClassicAssert.IsFalse(equal1);
+            Assert.That(equal1, Is.False);
         }
 
         [Test]
@@ -440,14 +438,14 @@ namespace GeoJSON.Net.Tests.Feature
             bool equal2 = false;
 
             var feature = new Net.Feature.Feature(new Point(new Position(12, 123)));
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature == feature;
                 equal2 = feature.Equals(feature);
             });
 
-            ClassicAssert.IsTrue(equal1);
-            ClassicAssert.IsTrue(equal2);
+            Assert.That(equal1);
+            Assert.That(equal2);
         }
 
         [Test]
@@ -459,14 +457,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(null);
             var feature2 = new Net.Feature.Feature(new Point(new Position(12, 123)));
 
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            ClassicAssert.IsFalse(equal1);
-            ClassicAssert.IsFalse(equal2);
+            Assert.That(equal1, Is.False);
+            Assert.That(equal2, Is.False);
         }
 
         [Test]
@@ -478,14 +476,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(new Point(new Position(12, 123)));
             var feature2 = new Net.Feature.Feature(null);
 
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            ClassicAssert.IsFalse(equal1);
-            ClassicAssert.IsFalse(equal2);
+            Assert.That(equal1, Is.False);
+            Assert.That(equal2, Is.False);
         }
 
         [Test]
@@ -497,14 +495,14 @@ namespace GeoJSON.Net.Tests.Feature
             var feature1 = new Net.Feature.Feature(null);
             var feature2 = new Net.Feature.Feature(null);
 
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature1 == feature2;
                 equal2 = feature1.Equals(feature2);
             });
 
-            ClassicAssert.IsTrue(equal1);
-            ClassicAssert.IsTrue(equal2);
+            Assert.That(equal1);
+            Assert.That(equal2);
         }
 
 
@@ -554,37 +552,37 @@ namespace GeoJSON.Net.Tests.Feature
 
         private void Assert_Are_Equal(Net.Feature.Feature left, Net.Feature.Feature right)
         {
-            ClassicAssert.AreEqual(left, right);
+            Assert.That(right, Is.EqualTo(left));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(right.Equals(left));
+            Assert.That(left.Equals(right));
+            Assert.That(right.Equals(left));
 
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.IsFalse(left != right);
-            ClassicAssert.IsFalse(right != left);
+            Assert.That(left != right, Is.False);
+            Assert.That(right != left, Is.False);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
 
         private void Assert_Are_Not_Equal(Net.Feature.Feature left, Net.Feature.Feature right)
         {
-            ClassicAssert.AreNotEqual(left, right);
+            Assert.That(right, Is.Not.EqualTo(left));
 
-            ClassicAssert.IsFalse(left.Equals(right));
-            ClassicAssert.IsFalse(right.Equals(left));
+            Assert.That(left.Equals(right), Is.False);
+            Assert.That(right.Equals(left), Is.False);
 
-            ClassicAssert.IsFalse(left == right);
-            ClassicAssert.IsFalse(right == left);
+            Assert.That(left == right, Is.False);
+            Assert.That(right == left, Is.False);
 
-            ClassicAssert.IsTrue(left != right);
-            ClassicAssert.IsTrue(right != left);
+            Assert.That(left != right);
+            Assert.That(right != left);
 
-            ClassicAssert.AreNotEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.Not.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Feature/GenericFeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/GenericFeatureTests.cs
@@ -4,7 +4,6 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Feature
 {
@@ -18,19 +17,19 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Feature<Point>>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Any());
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Any());
 
-            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual("Dinagat Islands", feature.Properties["name"]);
+            Assert.That(feature.Properties.ContainsKey("name"));
+            Assert.That(feature.Properties["name"], Is.EqualTo("Dinagat Islands"));
 
-            ClassicAssert.AreEqual("test-id", feature.Id);
+            Assert.That(feature.Id, Is.EqualTo("test-id"));
 
-            ClassicAssert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
-            ClassicAssert.AreEqual(125.6, feature.Geometry.Coordinates.Longitude);
-            ClassicAssert.AreEqual(10.1, feature.Geometry.Coordinates.Latitude);
-            ClassicAssert.AreEqual(456, feature.Geometry.Coordinates.Altitude);
+            Assert.That(feature.Geometry.Type, Is.EqualTo(GeoJSONObjectType.Point));
+            Assert.That(feature.Geometry.Coordinates.Longitude, Is.EqualTo(125.6));
+            Assert.That(feature.Geometry.Coordinates.Latitude, Is.EqualTo(10.1));
+            Assert.That(feature.Geometry.Coordinates.Altitude, Is.EqualTo(456));
         }
 
         [Test]
@@ -40,18 +39,18 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Feature<LineString>>(json);
 
-            ClassicAssert.IsNotNull(feature);
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.IsTrue(feature.Properties.Any());
+            Assert.That(feature, Is.Not.Null);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Any());
 
-            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
-            ClassicAssert.AreEqual("Dinagat Islands", feature.Properties["name"]);
+            Assert.That(feature.Properties.ContainsKey("name"));
+            Assert.That(feature.Properties["name"], Is.EqualTo("Dinagat Islands"));
 
-            ClassicAssert.AreEqual("test-id", feature.Id);
+            Assert.That(feature.Id, Is.EqualTo("test-id"));
 
-            ClassicAssert.AreEqual(GeoJSONObjectType.LineString, feature.Geometry.Type);
+            Assert.That(feature.Geometry.Type, Is.EqualTo(GeoJSONObjectType.LineString));
 
-            ClassicAssert.AreEqual(4, feature.Geometry.Coordinates.Count);
+            Assert.That(feature.Geometry.Coordinates.Count, Is.EqualTo(4));
 
             //Assert.AreEqual(125.6, feature.Geometry.Coordinates.Longitude);
             //Assert.AreEqual(10.1, feature.Geometry.Coordinates.Latitude);
@@ -73,14 +72,14 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = new Feature<Point, Dictionary<string, string>>(point, properties, "testid");
 
-            ClassicAssert.DoesNotThrow(() =>
+            Assert.DoesNotThrow(() =>
             {
                 equal1 = feature == null;
                 equal2 = feature.Equals(null);
             });
 
-            ClassicAssert.IsFalse(equal1);
-            ClassicAssert.IsFalse(equal2);
+            Assert.That(equal1, Is.False);
+            Assert.That(equal2, Is.False);
         }
 
         private class TypedFeatureProps
@@ -97,15 +96,15 @@ namespace GeoJSON.Net.Tests.Feature
             var json = GetExpectedJson();
             var feature = JsonConvert.DeserializeObject<Feature<Point, TypedFeatureProps>>(json);
 
-            ClassicAssert.IsNotNull(feature);
+            Assert.That(feature, Is.Not.Null);
 
-            ClassicAssert.IsNotNull(feature.Properties);
-            ClassicAssert.AreEqual(feature.Properties.Name, "Dinagat Islands");
-            ClassicAssert.AreEqual(feature.Properties.Value, 4.2);
+            Assert.That(feature.Properties, Is.Not.Null);
+            Assert.That(feature.Properties.Name, Is.EqualTo("Dinagat Islands"));
+            Assert.That(feature.Properties.Value, Is.EqualTo(4.2));
 
-            ClassicAssert.AreEqual(feature.Id, "test-id");
+            Assert.That(feature.Id, Is.EqualTo("test-id"));
 
-            ClassicAssert.AreEqual(feature.Geometry.Type, GeoJSONObjectType.Point);
+            Assert.That(feature.Geometry.Type, Is.EqualTo(GeoJSONObjectType.Point));
         }
 
 

--- a/src/GeoJSON.Net.Tests/Feature/GenericFeatureTests.cs
+++ b/src/GeoJSON.Net.Tests/Feature/GenericFeatureTests.cs
@@ -4,6 +4,7 @@ using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Feature
 {
@@ -17,19 +18,19 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Feature<Point>>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Any());
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Any());
 
-            Assert.IsTrue(feature.Properties.ContainsKey("name"));
-            Assert.AreEqual("Dinagat Islands", feature.Properties["name"]);
+            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual("Dinagat Islands", feature.Properties["name"]);
 
-            Assert.AreEqual("test-id", feature.Id);
+            ClassicAssert.AreEqual("test-id", feature.Id);
 
-            Assert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
-            Assert.AreEqual(125.6, feature.Geometry.Coordinates.Longitude);
-            Assert.AreEqual(10.1, feature.Geometry.Coordinates.Latitude);
-            Assert.AreEqual(456, feature.Geometry.Coordinates.Altitude);
+            ClassicAssert.AreEqual(GeoJSONObjectType.Point, feature.Geometry.Type);
+            ClassicAssert.AreEqual(125.6, feature.Geometry.Coordinates.Longitude);
+            ClassicAssert.AreEqual(10.1, feature.Geometry.Coordinates.Latitude);
+            ClassicAssert.AreEqual(456, feature.Geometry.Coordinates.Altitude);
         }
 
         [Test]
@@ -39,18 +40,18 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = JsonConvert.DeserializeObject<Feature<LineString>>(json);
 
-            Assert.IsNotNull(feature);
-            Assert.IsNotNull(feature.Properties);
-            Assert.IsTrue(feature.Properties.Any());
+            ClassicAssert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.IsTrue(feature.Properties.Any());
 
-            Assert.IsTrue(feature.Properties.ContainsKey("name"));
-            Assert.AreEqual("Dinagat Islands", feature.Properties["name"]);
+            ClassicAssert.IsTrue(feature.Properties.ContainsKey("name"));
+            ClassicAssert.AreEqual("Dinagat Islands", feature.Properties["name"]);
 
-            Assert.AreEqual("test-id", feature.Id);
+            ClassicAssert.AreEqual("test-id", feature.Id);
 
-            Assert.AreEqual(GeoJSONObjectType.LineString, feature.Geometry.Type);
+            ClassicAssert.AreEqual(GeoJSONObjectType.LineString, feature.Geometry.Type);
 
-            Assert.AreEqual(4, feature.Geometry.Coordinates.Count);
+            ClassicAssert.AreEqual(4, feature.Geometry.Coordinates.Count);
 
             //Assert.AreEqual(125.6, feature.Geometry.Coordinates.Longitude);
             //Assert.AreEqual(10.1, feature.Geometry.Coordinates.Latitude);
@@ -72,14 +73,14 @@ namespace GeoJSON.Net.Tests.Feature
 
             var feature = new Feature<Point, Dictionary<string, string>>(point, properties, "testid");
 
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 equal1 = feature == null;
                 equal2 = feature.Equals(null);
             });
 
-            Assert.IsFalse(equal1);
-            Assert.IsFalse(equal2);
+            ClassicAssert.IsFalse(equal1);
+            ClassicAssert.IsFalse(equal2);
         }
 
         private class TypedFeatureProps
@@ -96,15 +97,15 @@ namespace GeoJSON.Net.Tests.Feature
             var json = GetExpectedJson();
             var feature = JsonConvert.DeserializeObject<Feature<Point, TypedFeatureProps>>(json);
 
-            Assert.IsNotNull(feature);
+            ClassicAssert.IsNotNull(feature);
 
-            Assert.IsNotNull(feature.Properties);
-            Assert.AreEqual(feature.Properties.Name, "Dinagat Islands");
-            Assert.AreEqual(feature.Properties.Value, 4.2);
+            ClassicAssert.IsNotNull(feature.Properties);
+            ClassicAssert.AreEqual(feature.Properties.Name, "Dinagat Islands");
+            ClassicAssert.AreEqual(feature.Properties.Value, 4.2);
 
-            Assert.AreEqual(feature.Id, "test-id");
+            ClassicAssert.AreEqual(feature.Id, "test-id");
 
-            Assert.AreEqual(feature.Geometry.Type, GeoJSONObjectType.Point);
+            ClassicAssert.AreEqual(feature.Geometry.Type, GeoJSONObjectType.Point);
         }
 
 

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeoJSON.Net\GeoJSON.Net.csproj" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <ProjectReference Include="..\GeoJSON.Net\GeoJSON.Net.csproj" />
     <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{6C93B314-9208-4684-B873-172F7EC81689}</ProjectGuid>
     <RootNamespace>GeoJSON.Net.Tests</RootNamespace>
     <AssemblyName>GeoJSON.Net.Tests</AssemblyName>
-    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\GeoJSON.Net\GeoJSON.Net.csproj" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    
+
     <ProjectGuid>{6C93B314-9208-4684-B873-172F7EC81689}</ProjectGuid>
     <RootNamespace>GeoJSON.Net.Tests</RootNamespace>
     <AssemblyName>GeoJSON.Net.Tests</AssemblyName>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\GeoJSON.Net\GeoJSON.Net.csproj" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Feature\*.json">

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{6C93B314-9208-4684-B873-172F7EC81689}</ProjectGuid>
     <RootNamespace>GeoJSON.Net.Tests</RootNamespace>
     <AssemblyName>GeoJSON.Net.Tests</AssemblyName>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
+++ b/src/GeoJSON.Net.Tests/GeoJSON.Net.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeoJSON.Net\GeoJSON.Net.csproj" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>

--- a/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
@@ -4,6 +4,7 @@ using GeoJSON.Net.Converters;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -120,7 +121,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var deserializedGeometry = JsonConvert.DeserializeObject<IGeometryObject>(json, new GeometryConverter());
 
-            Assert.AreEqual(geometry, deserializedGeometry);
+            ClassicAssert.AreEqual(geometry, deserializedGeometry);
         }
 
         [Test]
@@ -128,7 +129,7 @@ namespace GeoJSON.Net.Tests.Geometry
         public void Serialization_Observes_Indenting_Setting_Of_Serializer(IGeometryObject geometry)
         {
             var json = JsonConvert.SerializeObject(geometry, Formatting.Indented);
-            Assert.IsTrue(json.Contains(Environment.NewLine));
+            ClassicAssert.IsTrue(json.Contains(Environment.NewLine));
         }
 
         [Test]
@@ -136,8 +137,8 @@ namespace GeoJSON.Net.Tests.Geometry
         public void Serialization_Observes_No_Indenting_Setting_Of_Serializer(IGeometryObject geometry)
         {
             var json = JsonConvert.SerializeObject(geometry, Formatting.None);
-            Assert.IsFalse(json.Contains(Environment.NewLine));
-            Assert.IsFalse(json.Contains(" "));
+            ClassicAssert.IsFalse(json.Contains(Environment.NewLine));
+            ClassicAssert.IsFalse(json.Contains(" "));
         }
 
         [Test]
@@ -150,7 +151,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var deserializedClassWithGeometry = JsonConvert.DeserializeObject<ClassWithGeometryProperty>(json);
 
-            Assert.AreEqual(classWithGeometry, deserializedClassWithGeometry);
+            ClassicAssert.AreEqual(classWithGeometry, deserializedClassWithGeometry);
         }
 
         [Test]
@@ -166,16 +167,16 @@ namespace GeoJSON.Net.Tests.Geometry
             var actual = classWithGeometry;
             var expected = deserializedClassWithGeometry;
             
-            Assert.IsTrue(actual.Equals(expected));
-            Assert.IsTrue(actual.Equals(actual));
+            ClassicAssert.IsTrue(actual.Equals(expected));
+            ClassicAssert.IsTrue(actual.Equals(actual));
 
-            Assert.IsTrue(expected.Equals(actual));
-            Assert.IsTrue(expected.Equals(expected));
+            ClassicAssert.IsTrue(expected.Equals(actual));
+            ClassicAssert.IsTrue(expected.Equals(expected));
 
-            Assert.IsTrue(classWithGeometry == deserializedClassWithGeometry);
-            Assert.IsTrue(deserializedClassWithGeometry == classWithGeometry);
+            ClassicAssert.IsTrue(classWithGeometry == deserializedClassWithGeometry);
+            ClassicAssert.IsTrue(deserializedClassWithGeometry == classWithGeometry);
 
-            Assert.AreEqual(actual.GetHashCode(), expected.GetHashCode());
+            ClassicAssert.AreEqual(actual.GetHashCode(), expected.GetHashCode());
         }
 
         internal class ClassWithGeometryProperty

--- a/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/GeometryTests.cs
@@ -4,7 +4,6 @@ using GeoJSON.Net.Converters;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -121,7 +120,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var deserializedGeometry = JsonConvert.DeserializeObject<IGeometryObject>(json, new GeometryConverter());
 
-            ClassicAssert.AreEqual(geometry, deserializedGeometry);
+            Assert.That(deserializedGeometry, Is.EqualTo(geometry));
         }
 
         [Test]
@@ -129,7 +128,7 @@ namespace GeoJSON.Net.Tests.Geometry
         public void Serialization_Observes_Indenting_Setting_Of_Serializer(IGeometryObject geometry)
         {
             var json = JsonConvert.SerializeObject(geometry, Formatting.Indented);
-            ClassicAssert.IsTrue(json.Contains(Environment.NewLine));
+            Assert.That(json.Contains(Environment.NewLine));
         }
 
         [Test]
@@ -137,8 +136,8 @@ namespace GeoJSON.Net.Tests.Geometry
         public void Serialization_Observes_No_Indenting_Setting_Of_Serializer(IGeometryObject geometry)
         {
             var json = JsonConvert.SerializeObject(geometry, Formatting.None);
-            ClassicAssert.IsFalse(json.Contains(Environment.NewLine));
-            ClassicAssert.IsFalse(json.Contains(" "));
+            Assert.That(json.Contains(Environment.NewLine), Is.False);
+            Assert.That(json.Contains(" "), Is.False);
         }
 
         [Test]
@@ -151,7 +150,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var deserializedClassWithGeometry = JsonConvert.DeserializeObject<ClassWithGeometryProperty>(json);
 
-            ClassicAssert.AreEqual(classWithGeometry, deserializedClassWithGeometry);
+            Assert.That(deserializedClassWithGeometry, Is.EqualTo(classWithGeometry));
         }
 
         [Test]
@@ -166,17 +165,17 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actual = classWithGeometry;
             var expected = deserializedClassWithGeometry;
-            
-            ClassicAssert.IsTrue(actual.Equals(expected));
-            ClassicAssert.IsTrue(actual.Equals(actual));
 
-            ClassicAssert.IsTrue(expected.Equals(actual));
-            ClassicAssert.IsTrue(expected.Equals(expected));
+            Assert.That(actual.Equals(expected));
+            Assert.That(actual.Equals(actual));
 
-            ClassicAssert.IsTrue(classWithGeometry == deserializedClassWithGeometry);
-            ClassicAssert.IsTrue(deserializedClassWithGeometry == classWithGeometry);
+            Assert.That(expected.Equals(actual));
+            Assert.That(expected.Equals(expected));
 
-            ClassicAssert.AreEqual(actual.GetHashCode(), expected.GetHashCode());
+            Assert.That(classWithGeometry == deserializedClassWithGeometry);
+            Assert.That(deserializedClassWithGeometry == classWithGeometry);
+
+            Assert.That(expected.GetHashCode(), Is.EqualTo(actual.GetHashCode()));
         }
 
         internal class ClassWithGeometryProperty

--- a/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -22,7 +23,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var lineString = new LineString(coordinates);
 
-            Assert.IsTrue(lineString.IsClosed());
+            ClassicAssert.IsTrue(lineString.IsClosed());
         }
 
         [Test]
@@ -38,7 +39,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var lineString = new LineString(coordinates);
 
-            Assert.IsFalse(lineString.IsClosed());
+            ClassicAssert.IsFalse(lineString.IsClosed());
         }
         
 
@@ -76,24 +77,24 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = GetExpectedJson();
             var actualLineString = JsonConvert.DeserializeObject<LineString>(json);
 
-            Assert.AreEqual(expectedLineString, actualLineString);
+            ClassicAssert.AreEqual(expectedLineString, actualLineString);
 
-            Assert.AreEqual(4, actualLineString.Coordinates.Count);
-            Assert.AreEqual(expectedLineString.Coordinates[0].Latitude, actualLineString.Coordinates[0].Latitude);
-            Assert.AreEqual(expectedLineString.Coordinates[0].Longitude, actualLineString.Coordinates[0].Longitude);
+            ClassicAssert.AreEqual(4, actualLineString.Coordinates.Count);
+            ClassicAssert.AreEqual(expectedLineString.Coordinates[0].Latitude, actualLineString.Coordinates[0].Latitude);
+            ClassicAssert.AreEqual(expectedLineString.Coordinates[0].Longitude, actualLineString.Coordinates[0].Longitude);
         }
 
         [Test]
         public void Constructor_No_Coordinates_Throws_Exception()
         {
             var coordinates = new List<IPosition>();
-            Assert.Throws<ArgumentOutOfRangeException>(() => new LineString(coordinates));
+            ClassicAssert.Throws<ArgumentOutOfRangeException>(() => new LineString(coordinates));
         }
 
         [Test]
         public void Constructor_Null_Coordinates_Throws_Exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new LineString((IEnumerable<IPosition>)null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new LineString((IEnumerable<IPosition>)null));
         }
 
         private LineString GetLineString(double offset = 0.0)
@@ -122,18 +123,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetLineString(offset);
             var right = GetLineString(offset);
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(right, left);
+            ClassicAssert.AreEqual(left, right);
+            ClassicAssert.AreEqual(right, left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/LineStringTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -23,7 +22,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var lineString = new LineString(coordinates);
 
-            ClassicAssert.IsTrue(lineString.IsClosed());
+            Assert.That(lineString.IsClosed());
         }
 
         [Test]
@@ -39,7 +38,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var lineString = new LineString(coordinates);
 
-            ClassicAssert.IsFalse(lineString.IsClosed());
+            Assert.That(lineString.IsClosed(), Is.False);
         }
         
 
@@ -77,24 +76,24 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = GetExpectedJson();
             var actualLineString = JsonConvert.DeserializeObject<LineString>(json);
 
-            ClassicAssert.AreEqual(expectedLineString, actualLineString);
+            Assert.That(actualLineString, Is.EqualTo(expectedLineString));
 
-            ClassicAssert.AreEqual(4, actualLineString.Coordinates.Count);
-            ClassicAssert.AreEqual(expectedLineString.Coordinates[0].Latitude, actualLineString.Coordinates[0].Latitude);
-            ClassicAssert.AreEqual(expectedLineString.Coordinates[0].Longitude, actualLineString.Coordinates[0].Longitude);
+            Assert.That(actualLineString.Coordinates.Count, Is.EqualTo(4));
+            Assert.That(actualLineString.Coordinates[0].Latitude, Is.EqualTo(expectedLineString.Coordinates[0].Latitude));
+            Assert.That(actualLineString.Coordinates[0].Longitude, Is.EqualTo(expectedLineString.Coordinates[0].Longitude));
         }
 
         [Test]
         public void Constructor_No_Coordinates_Throws_Exception()
         {
             var coordinates = new List<IPosition>();
-            ClassicAssert.Throws<ArgumentOutOfRangeException>(() => new LineString(coordinates));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new LineString(coordinates));
         }
 
         [Test]
         public void Constructor_Null_Coordinates_Throws_Exception()
         {
-            ClassicAssert.Throws<ArgumentNullException>(() => new LineString((IEnumerable<IPosition>)null));
+            Assert.Throws<ArgumentNullException>(() => new LineString((IEnumerable<IPosition>)null));
         }
 
         private LineString GetLineString(double offset = 0.0)
@@ -123,18 +122,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetLineString(offset);
             var right = GetLineString(offset);
 
-            ClassicAssert.AreEqual(left, right);
-            ClassicAssert.AreEqual(right, left);
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left, Is.EqualTo(right));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
@@ -2,7 +2,6 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -32,8 +31,8 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var multiLineString = JsonConvert.DeserializeObject<MultiLineString>(json);
 
-            ClassicAssert.IsNotNull(multiLineString);
-            ClassicAssert.AreEqual(expectedMultiLineString, multiLineString);
+            Assert.That(multiLineString, Is.Not.Null);
+            Assert.That(multiLineString, Is.EqualTo(expectedMultiLineString));
         }
 
         [Test]
@@ -99,18 +98,18 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var right = new MultiLineString(rightLine);
 
-            ClassicAssert.AreEqual(left, right);
-            ClassicAssert.AreEqual(right, left);
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left, Is.EqualTo(right));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiLineStringTests.cs
@@ -2,6 +2,7 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -31,8 +32,8 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var multiLineString = JsonConvert.DeserializeObject<MultiLineString>(json);
 
-            Assert.IsNotNull(multiLineString);
-            Assert.AreEqual(expectedMultiLineString, multiLineString);
+            ClassicAssert.IsNotNull(multiLineString);
+            ClassicAssert.AreEqual(expectedMultiLineString, multiLineString);
         }
 
         [Test]
@@ -98,18 +99,18 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var right = new MultiLineString(rightLine);
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(right, left);
+            ClassicAssert.AreEqual(left, right);
+            ClassicAssert.AreEqual(right, left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -40,7 +41,7 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = GetExpectedJson();
             var actualMultiPoint = JsonConvert.DeserializeObject<MultiPoint>(json);
 
-            Assert.AreEqual(expectedMultiPoint, actualMultiPoint);
+            ClassicAssert.AreEqual(expectedMultiPoint, actualMultiPoint);
         }
 
         private List<Point> GetPoints(double offset)
@@ -68,18 +69,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = new MultiPoint(GetPoints(offset));
             var right = new MultiPoint(GetPoints(offset));
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(right, left);
+            ClassicAssert.AreEqual(left, right);
+            ClassicAssert.AreEqual(right, left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPointTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -41,7 +40,7 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = GetExpectedJson();
             var actualMultiPoint = JsonConvert.DeserializeObject<MultiPoint>(json);
 
-            ClassicAssert.AreEqual(expectedMultiPoint, actualMultiPoint);
+            Assert.That(actualMultiPoint, Is.EqualTo(expectedMultiPoint));
         }
 
         private List<Point> GetPoints(double offset)
@@ -69,18 +68,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = new MultiPoint(GetPoints(offset));
             var right = new MultiPoint(GetPoints(offset));
 
-            ClassicAssert.AreEqual(left, right);
-            ClassicAssert.AreEqual(right, left);
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left, Is.EqualTo(right));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -17,7 +18,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualMultiPolygon = JsonConvert.DeserializeObject<MultiPolygon>(json);
 
-            Assert.AreEqual(expectMultiPolygon, actualMultiPolygon);
+            ClassicAssert.AreEqual(expectMultiPolygon, actualMultiPolygon);
         }
 
         private MultiPolygon GetMultiPolygon(double offset = 0.0)
@@ -122,18 +123,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetMultiPolygon(offset);
             var right = GetMultiPolygon(offset);
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(right, left);
+            ClassicAssert.AreEqual(left, right);
+            ClassicAssert.AreEqual(right, left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/MultiPolygonTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -18,7 +17,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualMultiPolygon = JsonConvert.DeserializeObject<MultiPolygon>(json);
 
-            ClassicAssert.AreEqual(expectMultiPolygon, actualMultiPolygon);
+            Assert.That(actualMultiPolygon, Is.EqualTo(expectMultiPolygon));
         }
 
         private MultiPolygon GetMultiPolygon(double offset = 0.0)
@@ -123,18 +122,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetMultiPolygon(offset);
             var right = GetMultiPolygon(offset);
 
-            ClassicAssert.AreEqual(left, right);
-            ClassicAssert.AreEqual(right, left);
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left, Is.EqualTo(right));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
@@ -1,6 +1,7 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -40,12 +41,12 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            Assert.IsNotNull(actualPoint);
-            Assert.IsNotNull(actualPoint.Coordinates);
-            Assert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
-            Assert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
-            Assert.AreEqual(200.4567, actualPoint.Coordinates.Altitude);
-            Assert.AreEqual(expectedPoint, actualPoint);
+            ClassicAssert.IsNotNull(actualPoint);
+            ClassicAssert.IsNotNull(actualPoint.Coordinates);
+            ClassicAssert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
+            ClassicAssert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
+            ClassicAssert.AreEqual(200.4567, actualPoint.Coordinates.Altitude);
+            ClassicAssert.AreEqual(expectedPoint, actualPoint);
         }
 
         [Test]
@@ -57,13 +58,13 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            Assert.IsNotNull(actualPoint);
-            Assert.IsNotNull(actualPoint.Coordinates);
-            Assert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
-            Assert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
-            Assert.IsFalse(actualPoint.Coordinates.Altitude.HasValue);
-            Assert.IsNull(actualPoint.Coordinates.Altitude);
-            Assert.AreEqual(expectedPoint, actualPoint);
+            ClassicAssert.IsNotNull(actualPoint);
+            ClassicAssert.IsNotNull(actualPoint.Coordinates);
+            ClassicAssert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
+            ClassicAssert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
+            ClassicAssert.IsFalse(actualPoint.Coordinates.Altitude.HasValue);
+            ClassicAssert.IsNull(actualPoint.Coordinates.Altitude);
+            ClassicAssert.AreEqual(expectedPoint, actualPoint);
         }
 
         [Test]
@@ -75,11 +76,11 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            Assert.AreEqual(expectedPoint, actualPoint);
-            Assert.IsTrue(expectedPoint.Equals(actualPoint));
-            Assert.IsTrue(actualPoint.Equals(expectedPoint));
+            ClassicAssert.AreEqual(expectedPoint, actualPoint);
+            ClassicAssert.IsTrue(expectedPoint.Equals(actualPoint));
+            ClassicAssert.IsTrue(actualPoint.Equals(expectedPoint));
 
-            Assert.AreEqual(expectedPoint.GetHashCode(), actualPoint.GetHashCode());
+            ClassicAssert.AreEqual(expectedPoint.GetHashCode(), actualPoint.GetHashCode());
         }
 
         [Test]

--- a/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PointTests.cs
@@ -1,7 +1,6 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -41,12 +40,12 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            ClassicAssert.IsNotNull(actualPoint);
-            ClassicAssert.IsNotNull(actualPoint.Coordinates);
-            ClassicAssert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
-            ClassicAssert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
-            ClassicAssert.AreEqual(200.4567, actualPoint.Coordinates.Altitude);
-            ClassicAssert.AreEqual(expectedPoint, actualPoint);
+            Assert.That(actualPoint, Is.Not.Null);
+            Assert.That(actualPoint.Coordinates, Is.Not.Null);
+            Assert.That(actualPoint.Coordinates.Latitude, Is.EqualTo(53.2455662));
+            Assert.That(actualPoint.Coordinates.Longitude, Is.EqualTo(90.65464646));
+            Assert.That(actualPoint.Coordinates.Altitude, Is.EqualTo(200.4567));
+            Assert.That(actualPoint, Is.EqualTo(expectedPoint));
         }
 
         [Test]
@@ -58,13 +57,13 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            ClassicAssert.IsNotNull(actualPoint);
-            ClassicAssert.IsNotNull(actualPoint.Coordinates);
-            ClassicAssert.AreEqual(53.2455662, actualPoint.Coordinates.Latitude);
-            ClassicAssert.AreEqual(90.65464646, actualPoint.Coordinates.Longitude);
-            ClassicAssert.IsFalse(actualPoint.Coordinates.Altitude.HasValue);
-            ClassicAssert.IsNull(actualPoint.Coordinates.Altitude);
-            ClassicAssert.AreEqual(expectedPoint, actualPoint);
+            Assert.That(actualPoint, Is.Not.Null);
+            Assert.That(actualPoint.Coordinates, Is.Not.Null);
+            Assert.That(actualPoint.Coordinates.Latitude, Is.EqualTo(53.2455662));
+            Assert.That(actualPoint.Coordinates.Longitude, Is.EqualTo(90.65464646));
+            Assert.That(actualPoint.Coordinates.Altitude.HasValue, Is.False);
+            Assert.That(actualPoint.Coordinates.Altitude, Is.Null);
+            Assert.That(actualPoint, Is.EqualTo(expectedPoint));
         }
 
         [Test]
@@ -76,11 +75,11 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPoint = JsonConvert.DeserializeObject<Point>(json);
 
-            ClassicAssert.AreEqual(expectedPoint, actualPoint);
-            ClassicAssert.IsTrue(expectedPoint.Equals(actualPoint));
-            ClassicAssert.IsTrue(actualPoint.Equals(expectedPoint));
+            Assert.That(actualPoint, Is.EqualTo(expectedPoint));
+            Assert.That(expectedPoint.Equals(actualPoint));
+            Assert.That(actualPoint.Equals(expectedPoint));
 
-            ClassicAssert.AreEqual(expectedPoint.GetHashCode(), actualPoint.GetHashCode());
+            Assert.That(actualPoint.GetHashCode(), Is.EqualTo(expectedPoint.GetHashCode()));
         }
 
         [Test]

--- a/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
@@ -3,7 +3,6 @@ using GeoJSON.Net.Converters;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -52,7 +51,7 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = JsonConvert.SerializeObject(polygon, serializerSettings);
             var result = JsonConvert.DeserializeObject<IGeometryObject>(json, serializerSettings);
 
-            ClassicAssert.AreEqual(result, polygon);
+            Assert.That(polygon, Is.EqualTo(result));
         }
 
         [Test]
@@ -266,7 +265,7 @@ namespace GeoJSON.Net.Tests.Geometry
             });
 
             var actualPolygon = JsonConvert.DeserializeObject<Polygon>(json);
-            ClassicAssert.AreEqual(expectedPolygon, actualPolygon);
+            Assert.That(actualPolygon, Is.EqualTo(expectedPolygon));
         }
 
         [Test]
@@ -287,7 +286,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPolygon = JsonConvert.DeserializeObject<Polygon>(json);
 
-            ClassicAssert.AreEqual(expectedPolygon, actualPolygon);
+            Assert.That(actualPolygon, Is.EqualTo(expectedPolygon));
         }
         
         [Test]
@@ -304,18 +303,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetPolygon(offset);
             var right = GetPolygon(offset);
 
-            ClassicAssert.AreEqual(left, right);
-            ClassicAssert.AreEqual(right, left);
+            Assert.That(right, Is.EqualTo(left));
+            Assert.That(left, Is.EqualTo(right));
 
-            ClassicAssert.IsTrue(left.Equals(right));
-            ClassicAssert.IsTrue(left.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(left));
-            ClassicAssert.IsTrue(right.Equals(right));
+            Assert.That(left.Equals(right));
+            Assert.That(left.Equals(left));
+            Assert.That(right.Equals(left));
+            Assert.That(right.Equals(right));
 
-            ClassicAssert.IsTrue(left == right);
-            ClassicAssert.IsTrue(right == left);
+            Assert.That(left == right);
+            Assert.That(right == left);
 
-            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.That(right.GetHashCode(), Is.EqualTo(left.GetHashCode()));
         }
 
         

--- a/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
+++ b/src/GeoJSON.Net.Tests/Geometry/PolygonTests.cs
@@ -3,6 +3,7 @@ using GeoJSON.Net.Converters;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Geometry
 {
@@ -51,7 +52,7 @@ namespace GeoJSON.Net.Tests.Geometry
             var json = JsonConvert.SerializeObject(polygon, serializerSettings);
             var result = JsonConvert.DeserializeObject<IGeometryObject>(json, serializerSettings);
 
-            Assert.AreEqual(result, polygon);
+            ClassicAssert.AreEqual(result, polygon);
         }
 
         [Test]
@@ -265,7 +266,7 @@ namespace GeoJSON.Net.Tests.Geometry
             });
 
             var actualPolygon = JsonConvert.DeserializeObject<Polygon>(json);
-            Assert.AreEqual(expectedPolygon, actualPolygon);
+            ClassicAssert.AreEqual(expectedPolygon, actualPolygon);
         }
 
         [Test]
@@ -286,7 +287,7 @@ namespace GeoJSON.Net.Tests.Geometry
 
             var actualPolygon = JsonConvert.DeserializeObject<Polygon>(json);
 
-            Assert.AreEqual(expectedPolygon, actualPolygon);
+            ClassicAssert.AreEqual(expectedPolygon, actualPolygon);
         }
         
         [Test]
@@ -303,18 +304,18 @@ namespace GeoJSON.Net.Tests.Geometry
             var left = GetPolygon(offset);
             var right = GetPolygon(offset);
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(right, left);
+            ClassicAssert.AreEqual(left, right);
+            ClassicAssert.AreEqual(right, left);
 
-            Assert.IsTrue(left.Equals(right));
-            Assert.IsTrue(left.Equals(left));
-            Assert.IsTrue(right.Equals(left));
-            Assert.IsTrue(right.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(right));
+            ClassicAssert.IsTrue(left.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(left));
+            ClassicAssert.IsTrue(right.Equals(right));
 
-            Assert.IsTrue(left == right);
-            Assert.IsTrue(right == left);
+            ClassicAssert.IsTrue(left == right);
+            ClassicAssert.IsTrue(right == left);
 
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            ClassicAssert.AreEqual(left.GetHashCode(), right.GetHashCode());
         }
 
         

--- a/src/GeoJSON.Net.Tests/JsonAssert.cs
+++ b/src/GeoJSON.Net.Tests/JsonAssert.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NUnit.Framework.Legacy;
+using NUnit.Framework;
 
 namespace GeoJSON.Net.Tests
 {
@@ -20,9 +20,8 @@ namespace GeoJSON.Net.Tests
         /// <param name="actualJson">The actual json.</param>
         public static void AreEqual(string expectJson, string actualJson)
         {
-            ClassicAssert.AreEqual(
-                JObject.Parse(expectJson).SortProperties().ToString(),
-                JObject.Parse(actualJson).SortProperties().ToString());
+            Assert.That(
+                JObject.Parse(actualJson).SortProperties().ToString(), Is.EqualTo(JObject.Parse(expectJson).SortProperties().ToString()));
         }
 
         /// <summary>
@@ -32,7 +31,7 @@ namespace GeoJSON.Net.Tests
         /// <param name="actualJson">The actual json.</param>
         public static void Contains(string expectedJson, string actualJson)
         {
-            ClassicAssert.IsTrue(actualJson.Contains(expectedJson), "expected {0} to contain {1}", actualJson, expectedJson);
+            Assert.That(actualJson.Contains(expectedJson), $"expected {actualJson} to contain {expectedJson}");
         }
 
         /// <summary>

--- a/src/GeoJSON.Net.Tests/JsonAssert.cs
+++ b/src/GeoJSON.Net.Tests/JsonAssert.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests
 {
@@ -20,7 +20,7 @@ namespace GeoJSON.Net.Tests
         /// <param name="actualJson">The actual json.</param>
         public static void AreEqual(string expectJson, string actualJson)
         {
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 JObject.Parse(expectJson).SortProperties().ToString(),
                 JObject.Parse(actualJson).SortProperties().ToString());
         }
@@ -32,7 +32,7 @@ namespace GeoJSON.Net.Tests
         /// <param name="actualJson">The actual json.</param>
         public static void Contains(string expectedJson, string actualJson)
         {
-            Assert.IsTrue(actualJson.Contains(expectedJson), "expected {0} to contain {1}", actualJson, expectedJson);
+            ClassicAssert.IsTrue(actualJson.Contains(expectedJson), "expected {0} to contain {1}", actualJson, expectedJson);
         }
 
         /// <summary>

--- a/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
+++ b/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
@@ -2,6 +2,7 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Serialization
 {
@@ -16,7 +17,7 @@ namespace GeoJSON.Net.Tests.Serialization
 
             var deserialized = JsonConvert.DeserializeObject<GeoJSONObject>(json, new GeoJsonConverter());
 
-            Assert.AreEqual(source, deserialized);
+            ClassicAssert.AreEqual(source, deserialized);
         }
 
         [Test]
@@ -28,7 +29,7 @@ namespace GeoJSON.Net.Tests.Serialization
 
             var deserialized = JsonConvert.DeserializeObject<IGeoJSONObject>(json, new GeoJsonConverter());
 
-            Assert.AreEqual(source, deserialized);
+            ClassicAssert.AreEqual(source, deserialized);
         }
     }
 }

--- a/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
+++ b/src/GeoJSON.Net.Tests/Serialization/JsonTests.cs
@@ -2,7 +2,6 @@
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace GeoJSON.Net.Tests.Serialization
 {
@@ -17,7 +16,7 @@ namespace GeoJSON.Net.Tests.Serialization
 
             var deserialized = JsonConvert.DeserializeObject<GeoJSONObject>(json, new GeoJsonConverter());
 
-            ClassicAssert.AreEqual(source, deserialized);
+            Assert.That(deserialized, Is.EqualTo(source));
         }
 
         [Test]
@@ -29,7 +28,7 @@ namespace GeoJSON.Net.Tests.Serialization
 
             var deserialized = JsonConvert.DeserializeObject<IGeoJSONObject>(json, new GeoJsonConverter());
 
-            ClassicAssert.AreEqual(source, deserialized);
+            Assert.That(deserialized, Is.EqualTo(source));
         }
     }
 }

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0;netstandard2.1;net462;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0;netstandard2.1;net462;net6.0</TargetFrameworks>
     <Description>.Net types for the GeoJSON RFC to be used with Json.Net</Description>
     <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer</Authors>
     <Company>GeoJSON.Net</Company>

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0;netstandard2.1;net40;net45;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0;netstandard2.1;net462;net5.0</TargetFrameworks>
     <Description>.Net types for the GeoJSON RFC to be used with Json.Net</Description>
     <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer</Authors>
     <Company>GeoJSON.Net</Company>

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net8.0</TargetFrameworks>
     <Description>.Net types for the GeoJSON RFC to be used with Json.Net</Description>
     <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer</Authors>
     <Company>GeoJSON.Net</Company>

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0;netstandard2.1;net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0</TargetFrameworks>
     <Description>.Net types for the GeoJSON RFC to be used with Json.Net</Description>
     <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer</Authors>
     <Company>GeoJSON.Net</Company>


### PR DESCRIPTION
This PR updates the target frameworks and package dependencies to an acceptable state.

Concerning the target framworks:
* The .NET Framework versions 4.0 and 4.5 are out of support, and are thus replaced by .NET Framework 4.6.2.
* The .NET (Core) versions 3.1 and 5.0 (also out of support) are replaced by .NET 6.0.

References:
* https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
* https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

Concerning the package dependencies:
* Microsoft.NET.Test.Sdk is updated from 15.0.0 to 17.10.0 (latest stable version).
* NUnit3TestAdapter is updated from 3.8.0 to 4.5.0 (latest stable version).
* NUnit is updated from 3.7.1 to 4.1.0 (latest stable version). This is the only update with breaking changes (fixed via purely mechanical replacments).

All package updates only affect the test project (GeoJSON.Net.Tests), but not the library (GeoJSON.Net) itself.

@xfischer Does this look good to you, or do you have any objections?