### PR TITLE
Release 1.4.0

### DIFF
--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -3,24 +3,19 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0;net8.0</TargetFrameworks>
     <Description>.Net types for the GeoJSON RFC to be used with Json.Net</Description>
-    <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer</Authors>
+    <Authors>Matt Hunt;Joerg Battermann;Xavier Fischer;Janus Weil</Authors>
     <Company>GeoJSON.Net</Company>
-    <Copyright>Copyright © Joerg Battermann, Matt Hunt, Xavier Fischer and Contributors, 2014 - 2019</Copyright>
+    <Copyright>Copyright © Joerg Battermann, Matt Hunt, Xavier Fischer, Janus Weil and Contributors, 2014 - 2024</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.16</Version>
+    <Version>1.4.0</Version>
     <PackageProjectUrl>https://github.com/GeoJSON-Net/GeoJSON.Net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GeoJSON-Net/GeoJSON.Net.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>geojson;geo;json;geolocation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Fixes exception when serializing polygons</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
@xfischer What do you think about preparing a release now? For my taste, 1.4.0 would be an  appropriate version number.

This PR sets this version in the csproj, together with some additional minor changes:
* Updating the copyright year.
* Removing an outdated `PropertyGroup` (which refers to net35).
* Removing the release notes from the csproj (which IMHO is not an ideal place for it). Possible alternatives might be:
  - Adding a ReleaseNotes.md to the repository.
  - Having the release notes on the GitHub Releases page.
 
What I would do to release this:
* Merge this PR to master.
* Set a tag `1.4.0`.
* Let GHA build the package.
* Upload it to nuget.org (I currently do not have the permissions to do that).

Objections? Comments? Do we need any further changes before the release?